### PR TITLE
[26]  Don't require a .env file to function

### DIFF
--- a/src/setup.rs
+++ b/src/setup.rs
@@ -61,8 +61,12 @@ pub fn read_environmental_variables() {
     match dotenvy::dotenv() {
         Ok(_) => info!("loaded .env"),
         Err(e) => {
-            error!("Error reading .env file: {e}");
-            panic!();
+            if e.not_found() {
+                info!("no .env file found; skipping...");
+            } else {
+                error!("error loading .env file!: {e}");
+                panic!();
+            }
         }
     }
 }


### PR DESCRIPTION
As said in #26:
> .env files are near essential to running on bare metal and in development builds - but requiring their inclusion in deployment scenarios that utilise docker is a pain.

Closes #26 