### PR TITLE
[32] unify database url env variable naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Tau is the debatecore debate tournament planner project's response cannon - also
 The easiest way to develop locally is via a combination of docker and cargo - using docker to handle the database and cargo to handle the rest.
 This setup requires a few environment variables:
 - `DOCKER_DB_ROOT_PASSWORD` will be used as the password for the database root user.
-- `POSTGRESQL_CONNECTION_URI` will be used to connect to the database. During development, this is `postgres://tau:tau@localhost:5432/tau` by default.
+- `DATABASE_URL` will be used to connect to the database. During development, this is `postgres://tau:tau@localhost:5432/tau` by default.
 You may create a `.env` file in the root of the project or just set the environment variables in your shell.
 
 Next comes the database, which you can turn on with `docker compose --profile dev up -d`. You can run the migrations with `sqlx migrate run` to set up the database.

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -16,7 +16,7 @@ pub async fn get_connection_pool() -> Pool<Postgres> {
 }
 
 async fn connect_to_database() -> Result<Pool<Postgres>, sqlx::Error> {
-    let connection_uri = env::var("POSTGRESQL_CONNECTION_URI")
+    let connection_uri = env::var("DATABASE_URL")
         .expect("POSTGRESQL_CONNECTION_URI must be defined in .env");
 
     let options =

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -17,7 +17,7 @@ pub async fn get_connection_pool() -> Pool<Postgres> {
 
 async fn connect_to_database() -> Result<Pool<Postgres>, sqlx::Error> {
     let connection_uri = env::var("DATABASE_URL")
-        .expect("POSTGRESQL_CONNECTION_URI must be defined in .env");
+        .expect("DATABASE_URL must be defined in .env");
 
     let options =
         PgConnectOptions::from_str(&connection_uri).expect("Connection URI is invalid");


### PR DESCRIPTION
Database now uses `DATABASE_URL`. Closes #32 