### PR TITLE
[30] report git head match state in /version-details

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,6 +2,7 @@ use std::process::Command;
 
 fn main() {
     println!("cargo:rerun-if-changed=migrations");
+    println!("cargo:rerun-if-changed=src");
     println!("cargo:rerun-if-changed=.git/index");
     println!("cargo:rerun-if-changed=.git/HEAD");
 

--- a/build.rs
+++ b/build.rs
@@ -2,6 +2,9 @@ use std::process::Command;
 
 fn main() {
     println!("cargo:rerun-if-changed=migrations");
+    println!("cargo:rerun-if-changed=.git/index");
+    println!("cargo:rerun-if-changed=.git/HEAD");
+
     println!("cargo::rustc-env=GIT_COMMIT_HASH=UNKNOWN!");
     match Command::new("git").args(&["rev-parse", "HEAD"]).output() {
         Ok(output) => match String::from_utf8(output.stdout) {

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,7 @@
 use std::process::Command;
 
 fn main() {
+    println!("cargo:rerun-if-changed=migrations");
     println!("cargo::rustc-env=GIT_COMMIT_HASH=UNKNOWN!");
     match Command::new("git").args(&["rev-parse", "HEAD"]).output() {
         Ok(output) => match String::from_utf8(output.stdout) {
@@ -14,5 +15,21 @@ fn main() {
         },
         Err(_) => (),
     };
-    println!("cargo:rerun-if-changed=migrations");
+    println!("cargo::rustc-env=GIT_STATUS_PORCELAIN=UNKNOWN!");
+    match Command::new("git")
+        .args(&["status", "--porcelain"])
+        .output()
+    {
+        Ok(output) => match String::from_utf8(output.stdout) {
+            Ok(status) => {
+                if status.is_empty() {
+                    println!("cargo::rustc-env=GIT_STATUS_PORCELAIN=clean");
+                } else {
+                    println!("cargo::rustc-env=GIT_STATUS_PORCELAIN=changed")
+                }
+            }
+            Err(_) => (),
+        },
+        Err(_) => (),
+    }
 }

--- a/src/routes/version.rs
+++ b/src/routes/version.rs
@@ -13,7 +13,7 @@ pub fn route() -> Router {
 pub struct VersionDetails {
     version: &'static str,
     version_bits: VersionBits,
-    git_commit_hash: &'static str,
+    git_info: GitInfo,
     current_endpoint_prefix: &'static str,
     repository: &'static str,
 }
@@ -23,6 +23,14 @@ pub struct VersionBits {
     major: &'static str,
     minor: &'static str,
     patch: &'static str,
+}
+
+#[derive(Serialize, ToSchema)]
+pub struct GitInfo {
+    /// latest git commit hash, or 'UNKNOWN!'
+    git_commit_hash: &'static str,
+    /// this is either 'clean', 'changed' or 'UNKNOWN!'
+    git_status_porcelain: &'static str,
 }
 
 /// Returns API version
@@ -57,7 +65,10 @@ async fn version_details() -> Json<VersionDetails> {
             minor: env!("CARGO_PKG_VERSION_MINOR"),
             patch: env!("CARGO_PKG_VERSION_PATCH"),
         },
-        git_commit_hash: env!("GIT_COMMIT_HASH"),
+        git_info: GitInfo {
+            git_commit_hash: env!("GIT_COMMIT_HASH"),
+            git_status_porcelain: env!("GIT_STATUS_PORCELAIN"),
+        },
         current_endpoint_prefix: env!("CARGO_PKG_VERSION_MAJOR"),
         repository: env!("CARGO_PKG_REPOSITORY"),
     })


### PR DESCRIPTION
In addition to the latest git commit hash, `/version-details` now returns `git_status_porcelain`, which is `clean`, `changed` or `UNKNOWN!` to show whether there are any changes relative to the referenced commit in the built binary.

Closes #30 

<img width="1431" alt="image" src="https://github.com/user-attachments/assets/13b06b85-eddf-4770-81fb-4562ed7ec418" />
