### PR TITLE
[69] Get teams instead of getting debates

### DIFF
--- a/src/routes/team_routes.rs
+++ b/src/routes/team_routes.rs
@@ -117,7 +117,7 @@ async fn get_teams(
     }
 
     let tournament = Tournament::get_by_id(tournament_id, pool).await?;
-    match tournament.get_debates(pool).await
+    match tournament.get_teams(pool).await
     {
         Ok(teams) => Ok(Json(teams).into_response()),
         Err(e) => {

--- a/src/routes/tournament_routes.rs
+++ b/src/routes/tournament_routes.rs
@@ -26,6 +26,7 @@ pub fn route() -> Router<AppState> {
 /// 
 /// This request only returns the tournaments the user is permitted to see.
 /// The user must be given any role within a tournament to see it.
+/// The infrastructure admin can see all tournaments
 #[utoipa::path(get, path = "/tournament", 
     responses(
         (
@@ -51,6 +52,9 @@ async fn get_tournaments(
     let user = User::authenticate(&headers, cookies, pool).await?;
 
     let tournaments = Tournament::get_all(pool).await?;
+    if user.is_infrastructure_admin() {
+        return Ok(Json(tournaments).into_response());
+    }
     let mut visible_tournaments: Vec<Tournament> = vec![];
     for tournament in tournaments {
         let tournament_id = tournament.id;

--- a/src/routes/tournament_routes.rs
+++ b/src/routes/tournament_routes.rs
@@ -52,9 +52,6 @@ async fn get_tournaments(
     let user = User::authenticate(&headers, cookies, pool).await?;
 
     let tournaments = Tournament::get_all(pool).await?;
-    if user.is_infrastructure_admin() {
-        return Ok(Json(tournaments).into_response());
-    }
     let mut visible_tournaments: Vec<Tournament> = vec![];
     for tournament in tournaments {
         let tournament_id = tournament.id;


### PR DESCRIPTION
This PR fixes a bug occurring when using `GET /tournament` as infrastructure admin.