### PR TITLE
[75] fix tournament list response being empty octet stream; docs, indentation

### DIFF
--- a/src/routes/tournament_routes.rs
+++ b/src/routes/tournament_routes.rs
@@ -39,6 +39,7 @@ pub fn route() -> Router<AppState> {
             example=json!(get_tournaments_list_example())
         ),
         (status=400, description = "Bad request"),
+        (status=401, description = "Unauthorized; user auth not present or invalid"),
         (status=500, description = "Internal server error")
     ),
     tag="tournament"

--- a/src/routes/tournament_routes.rs
+++ b/src/routes/tournament_routes.rs
@@ -1,4 +1,9 @@
-use crate::{omni_error::OmniError, setup::AppState, tournament::{Tournament, TournamentPatch}, users::{permissions::Permission, TournamentUser, User}};
+use crate::{
+    omni_error::OmniError,
+    setup::AppState,
+    tournament::{Tournament, TournamentPatch},
+    users::{permissions::Permission, TournamentUser, User},
+};
 use axum::{
     extract::{Path, State},
     http::{HeaderMap, StatusCode},
@@ -9,7 +14,6 @@ use axum::{
 use tower_cookies::Cookies;
 use tracing::error;
 use uuid::Uuid;
-
 
 pub fn route() -> Router<AppState> {
     Router::new()
@@ -23,11 +27,11 @@ pub fn route() -> Router<AppState> {
 }
 
 /// Get a list of all tournaments
-/// 
+///
 /// This request only returns the tournaments the user is permitted to see.
 /// The user must be given any role within a tournament to see it.
 /// The infrastructure admin can see all tournaments
-#[utoipa::path(get, path = "/tournament", 
+#[utoipa::path(get, path = "/tournament",
     responses(
         (
             status=200, description = "Ok",
@@ -35,10 +39,6 @@ pub fn route() -> Router<AppState> {
             example=json!(get_tournaments_list_example())
         ),
         (status=400, description = "Bad request"),
-        (
-            status=401, 
-            description = "The user is not permitted to list any tournaments, meaning they do not have any roles within any tournament."
-        ),
         (status=500, description = "Internal server error")
     ),
     tag="tournament"
@@ -58,20 +58,17 @@ async fn get_tournaments(
         let roles = user.get_roles(tournament_id, pool).await?;
         let tournament_user = TournamentUser {
             user: user.clone(),
-            roles
+            roles,
         };
         if tournament_user.has_permission(Permission::ReadTournament) {
             visible_tournaments.push(tournament);
         }
     }
-    if visible_tournaments.is_empty() {
-        return Ok(vec![].into_response());
-    }
     Ok(Json(visible_tournaments).into_response())
 }
 
 /// Create a new tournament
-/// 
+///
 /// Available only to the infrastructure admin.
 #[utoipa::path(
     post,
@@ -80,14 +77,14 @@ async fn get_tournaments(
     responses
     (
         (
-            status=200, 
+            status=200,
             description = "Tournament created successfully",
             body=Tournament,
             example=json!(get_tournament_example_with_id())
         ),
         (status=400, description = "Bad request"),
         (
-            status=401, 
+            status=401,
             description = "The user is not permitted to modify this tournament"
         ),
         (status=404, description = "Tournament not found"),
@@ -112,9 +109,9 @@ async fn create_tournament(
 }
 
 /// Get details of an existing tournament
-/// 
+///
 /// The user must be given any role within the tournament to use this endpoint.
-#[utoipa::path(get, path = "/tournament/{id}", 
+#[utoipa::path(get, path = "/tournament/{id}",
     responses
     (
         (
@@ -124,7 +121,7 @@ async fn create_tournament(
         ),
         (status=400, description = "Bad request"),
         (
-            status=401, 
+            status=401,
             description = "The user is not permitted to read this tournament"
         ),
         (status=404, description = "Tournament not found"),
@@ -154,9 +151,9 @@ async fn get_tournament_by_id(
 }
 
 /// Patch an existing tournament
-/// 
+///
 /// Requires either the Organizer or Admin role.
-#[utoipa::path(patch, path = "/tournament/{id}", 
+#[utoipa::path(patch, path = "/tournament/{id}",
     request_body=TournamentPatch,
     responses(
         (
@@ -166,7 +163,7 @@ async fn get_tournament_by_id(
         ),
         (status=400, description = "Bad request"),
         (
-            status=401, 
+            status=401,
             description = "The user is not permitted to modify this tournament"
         ),
         (status=404, description = "Tournament not found"),
@@ -202,13 +199,12 @@ async fn patch_tournament_by_id(
     }
 }
 
-
 /// Delete an existing tournament.
-/// 
+///
 /// Available only to the tournament Organizers.
 /// This operation is only allowed when there are no resources
 /// referencing this tournament.
-#[utoipa::path(delete, path = "/tournament/{id}", 
+#[utoipa::path(delete, path = "/tournament/{id}",
     responses(
         (status=204, description = "Tournament deleted successfully"),
         (status=400, description = "Bad request"),
@@ -237,16 +233,14 @@ async fn delete_tournament_by_id(
     let tournament = Tournament::get_by_id(id, pool).await?;
     match tournament.delete(pool).await {
         Ok(_) => Ok(StatusCode::NO_CONTENT.into_response()),
-        Err(e) =>
-        {
+        Err(e) => {
             if e.is_sqlx_foreign_key_violation() {
-                return Err(OmniError::DependentResourcesError)
-            }
-            else {
+                return Err(OmniError::DependentResourcesError);
+            } else {
                 error!("Error deleting a tournament with id {id}: {e}");
                 return Err(e)?;
             }
-        },
+        }
     }
 }
 
@@ -275,5 +269,6 @@ fn get_tournaments_list_example() -> String {
         "shortened_name": "PND"
         }
         ]
-    "#.to_owned()
+    "#
+    .to_owned()
 }


### PR DESCRIPTION
Closes #75 by implementing the outlined fixes. Also aligns indentation with whatever rustfmt outputs.