### PR TITLE
[81] Sidechannel timing attack vulnerability

### DIFF
--- a/src/users/auth/userimpl.rs
+++ b/src/users/auth/userimpl.rs
@@ -9,6 +9,8 @@ use base64::{prelude::BASE64_STANDARD, Engine};
 use sqlx::{types::chrono::Utc, Pool, Postgres};
 use tower_cookies::Cookies;
 
+const MOCK_HASH: &str = "$argon2id$v=19$m=19456,t=2,p=1$vIgdgnSmGt7/do39njKQyQ$zkw1WQJoEd1bstFFXtozUyv5gA//Rhe4R+takjZCioE";
+
 impl User {
     pub async fn authenticate(
         headers: &HeaderMap,
@@ -62,7 +64,7 @@ impl User {
         password: &str,
         pool: &Pool<Postgres>,
     ) -> Result<User, OmniError> {
-        let hash = match sqlx::query!(
+        let saved_hash = match sqlx::query!(
             "SELECT password_hash FROM users WHERE handle = $1",
             login
         )
@@ -71,12 +73,13 @@ impl User {
         {
             Ok(hash) => hash.password_hash,
             Err(e) => match e {
-                sqlx::Error::RowNotFound => return Err(AuthError::InvalidCredentials)?,
+                // Hashes must always be compared to even out response times
+                sqlx::Error::RowNotFound => MOCK_HASH.to_owned(),
                 _ => return Err(OmniError::SqlxError(e))?,
             },
         };
         let argon = Argon2::default();
-        let hash = match PasswordHash::new(&hash) {
+        let hash = match PasswordHash::new(&saved_hash) {
             Ok(hash) => hash,
             Err(e) => return Err(e)?,
         };
@@ -86,6 +89,7 @@ impl User {
             false => Err(AuthError::InvalidCredentials)?,
         }
     }
+
     pub async fn auth_via_session(
         token: &str,
         cookies: Cookies,

--- a/src/users/queries.rs
+++ b/src/users/queries.rs
@@ -132,7 +132,7 @@ impl User {
         }
     }
 
-    fn generate_password_hash(password: &str) -> Result<String, OmniError> {
+    pub fn generate_password_hash(password: &str) -> Result<String, OmniError> {
         let hash = {
             let argon = Argon2::default();
             let salt = SaltString::generate(&mut OsRng);


### PR DESCRIPTION
I tried a few approaches to even out response times as much as possible. In the end I opted for comparing presented password with a mock hash if a user does not exist. The results seem satisfactory.

**Current `/user/auth` response times (ms)**

Test no.  | Admin | Fake user
-- | -- | --
1 | 535 | 11
2 | 482 | 17
3 | 482 | 4
4 | 472 | 14
5 | 443 | 4
6 | 443 | 4
7 | 451 | 5
8 | 477 | 9
9 | 441 | 4
10 | 451 | 5
Average response time | 467.7 | 7.7

**New `/user/auth` response times (ms)**

Test no.  | Admin | Fake user
-- | -- | --
1 | 470 | 469
2 | 460 | 455
3 | 458 | 439
4 | 448 | 442
5 | 456 | 453
6 | 460 | 467
7 | 485 | 466
8 | 481 | 469
9 | 462 | 508
10 | 457 | 491
Average response time | 463.7 | 465.9