### PR TITLE
fix: revert socket address change, prepare queries, refactor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,6 @@ USER appuser
 
 COPY --from=build /bin/server /bin/
 
-EXPOSE 2023
+EXPOSE ${PORT}
 
 CMD ["/bin/server"]

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -52,7 +52,7 @@ fn get_env_port() -> u16 {
 }
 
 pub fn get_socket_addr() -> SocketAddrV4 {
-    SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), get_env_port())
+    SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), get_env_port())
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
**Introduced changes**
This PR reverts recent changes in `setup::get_socket_addr()`, as the previous setup caused the connections to be refused in Docker environments.

@arsansomuncu, as it turns out, `0.0.0.0` simply isn't a rootable address on Windows. For testing purposes you'll either have to change this line locally or set up a [Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/install) and develop your code from there.

**Testing**
- [ ] ~~I have covered my code with tests~~ (not applicable).
- [x] I have run integration tests with `cargo test --tests` and ensured that they pass.
