### PR TITLE
Scrum 73 tournaments tournament id debates id returns a 500

### DIFF
--- a/src/routes/debate_routes.rs
+++ b/src/routes/debate_routes.rs
@@ -151,8 +151,7 @@ async fn get_debate_by_id(
     State(state): State<AppState>,
     headers: HeaderMap,
     cookies: Cookies,
-    Path(tournament_id): Path<Uuid>,
-    Path(id): Path<Uuid>,
+    Path((tournament_id, debate_id)): Path<(Uuid, Uuid)>,
 ) -> Result<Response, OmniError> {
     let pool = &state.connection_pool;
     let tournament_user =
@@ -163,13 +162,13 @@ async fn get_debate_by_id(
         false => return Err(OmniError::InsufficientPermissionsError),
     }
 
-    match Debate::get_by_id(id, &state.connection_pool).await {
+    match Debate::get_by_id(debate_id, &state.connection_pool).await {
         Ok(debate) => Ok(Json(debate).into_response()),
         Err(e) => match e {
             OmniError::ResourceNotFoundError => Err(e),
             _ => {
-                error!("Error getting a debate with id {id}: {e}");
-                Err(e)?
+                error!("Error getting a debate with id {debate_id}: {e}");
+                Err(OmniError::InternalServerError)
             }
         },
     }
@@ -247,8 +246,7 @@ async fn delete_debate_by_id(
     State(state): State<AppState>,
     headers: HeaderMap,
     cookies: Cookies,
-    Path(tournament_id): Path<Uuid>,
-    Path(id): Path<Uuid>,
+    Path((tournament_id, debate_id)): Path<(Uuid, Uuid)>,
 ) -> Result<Response, OmniError> {
     let pool = &state.connection_pool;
     let tournament_user =
@@ -259,7 +257,7 @@ async fn delete_debate_by_id(
         false => return Err(OmniError::InsufficientPermissionsError),
     }
 
-    match Debate::get_by_id(id, &state.connection_pool).await {
+    match Debate::get_by_id(debate_id, &state.connection_pool).await {
         Ok(debate) => match debate.delete(&state.connection_pool).await {
             Ok(_) => Ok(StatusCode::NO_CONTENT.into_response()),
             Err(e) => match e {

--- a/src/routes/location_routes.rs
+++ b/src/routes/location_routes.rs
@@ -50,7 +50,7 @@ pub fn route() -> Router<AppState> {
         (status=400, description = "Bad request"),
         (status=401, description = "Authentication error"),
         (
-            status=403, 
+            status=403,
             description = "The user is not permitted to modify locations within this tournament"
         ),
         (status=404, description = "Tournament or location not found"),
@@ -101,7 +101,7 @@ async fn create_location(
         (status=400, description = "Bad request"),
         (status=401, description = "Authentication error"),
         (
-            status=403, 
+            status=403,
             description = "The user is not permitted to read locations within this tournament"
         ),
         (status=404, description = "Tournament or location not found"),
@@ -156,7 +156,7 @@ async fn get_locations(
         (status=400, description = "Bad request"),
         (status=401, description = "Authentication error"),
         (
-            status=403, 
+            status=403,
             description = "The user is not permitted to read locations within this tournament"
         ),
         (status=404, description = "Tournament or location not found"),
@@ -202,7 +202,7 @@ async fn get_location_by_id(
         (status=400, description = "Bad request"),
         (status=401, description = "Authentication error"),
         (
-            status=403, 
+            status=403,
             description = "The user is not permitted to modify locations within this tournament"
         ),
         (status=404, description = "Tournament or location not found"),
@@ -262,7 +262,7 @@ async fn patch_location_by_id(
         (status=400, description = "Bad request"),
         (status=401, description = "Authentication error"),
         (
-            status=403, 
+            status=403,
             description = "The user is not permitted to modify locations within this tournament"
         ),
         (status=404, description = "Tournament or location not found"),

--- a/tests/integration_tests/affiliations_tests.rs
+++ b/tests/integration_tests/affiliations_tests.rs
@@ -9,7 +9,7 @@ use crate::common::{
         create_affiliation, delete_affiliation, get_affiliation, get_all_affiliations,
         get_id_of_a_new_affiliation, patch_affiliation,
     },
-    create_app, create_listener, prepare_empty_database,
+    create_app, create_listener, get_response_json, prepare_empty_database,
     teams_utils::get_id_of_a_new_team,
     tournament_utils::get_id_of_a_new_tournament,
     user_utils::{
@@ -41,15 +41,9 @@ async fn organizers_should_be_able_to_create_affiliations() -> Result<(), OmniEr
     // THEN
     assert_eq!(response.status(), StatusCode::OK);
 
-    let response_body = response.json::<serde_json::Value>().await.unwrap();
-    assert_eq!(
-        response_body["judge_user_id"].as_str().unwrap().to_owned(),
-        judge_id.to_owned()
-    );
-    assert_eq!(
-        response_body["team_id"].as_str().unwrap().to_owned(),
-        team_id
-    );
+    let response_body = get_response_json(response).await?;
+    assert_eq!(response_body["judge_user_id"], judge_id.to_owned());
+    assert_eq!(response_body["team_id"], team_id);
     Ok(())
 }
 

--- a/tests/integration_tests/common/debates_utils.rs
+++ b/tests/integration_tests/common/debates_utils.rs
@@ -49,14 +49,14 @@ pub async fn create_debate(tournament_id: &str, round_id: &str, token: &str) -> 
         .unwrap()
 }
 
-pub async fn get_debate(id: &str, judge_id: &str, token: &str) -> Response {
+pub async fn get_debate(id: &str, tournament_id: &str, token: &str) -> Response {
     let socket_address = get_socket_addr();
     let client = Client::new();
 
     client
         .get(format!(
-            "http://{}/users/{}/debates/{}",
-            socket_address, judge_id, id
+            "http://{}/tournaments/{}/debates/{}",
+            socket_address, tournament_id, id
         ))
         .header("accept", "application/json")
         .bearer_auth(token)

--- a/tests/integration_tests/common/mod.rs
+++ b/tests/integration_tests/common/mod.rs
@@ -1,4 +1,5 @@
 use axum::{routing::IntoMakeService, Router};
+use reqwest::Response;
 use sqlx::{Pool, Postgres};
 use tokio::net::TcpListener;
 use tower_cookies::CookieManagerLayer;
@@ -6,16 +7,18 @@ pub mod affiliations_utils;
 pub mod auth_utils;
 pub mod debates_utils;
 pub mod phases_utils;
+pub mod plans_utils;
 pub mod roles_utils;
 pub mod rounds_utils;
 pub mod teams_utils;
 pub mod tournament_utils;
 pub mod user_utils;
-pub mod plans_utils;
 pub mod verdicts_utils;
 
 use tau::{
-    database, routes,
+    database,
+    omni_error::OmniError,
+    routes,
     setup::{self, AppState},
     users::infradmin::guarantee_infrastructure_admin_exists,
 };
@@ -41,4 +44,25 @@ pub async fn create_app(state: AppState) -> IntoMakeService<Router> {
 pub async fn create_listener() -> TcpListener {
     let addr = setup::get_socket_addr();
     TcpListener::bind(addr).await.unwrap()
+}
+
+/// TO-DO: refactor existing tests to use this function
+pub async fn get_response_json(
+    response: Response,
+) -> Result<serde_json::Value, OmniError> {
+    let status = response.status();
+    let text = match response.text().await {
+        Ok(text) => text,
+        Err(e) => format!("{}", e).to_string(),
+    };
+
+    serde_json::from_str::<serde_json::Value>(&text).map_err(|e| {
+        OmniError::ExplicitError {
+            status,
+            message: format!(
+                "Failed to parse response body\nError message: {}\nResponse text: {}",
+                e, text
+            ),
+        }
+    })
 }

--- a/tests/integration_tests/debates_tests.rs
+++ b/tests/integration_tests/debates_tests.rs
@@ -1,0 +1,39 @@
+use std::future::IntoFuture;
+
+use reqwest::StatusCode;
+use serial_test::serial;
+use tau::{omni_error::OmniError, setup};
+
+use crate::common::{
+    create_app, create_listener,
+    debates_utils::{get_debate, get_id_of_a_new_debate},
+    prepare_empty_database,
+    tournament_utils::get_id_of_a_new_tournament,
+    user_utils::{get_id_of_a_new_user, get_organizer_token},
+};
+
+#[tokio::test]
+#[serial]
+async fn everyone_can_get_debate_details() -> Result<(), OmniError> {
+    // GIVEN
+    setup::read_environmental_variables();
+    setup::check_secret_env_var();
+    let state = setup::create_app_state().await;
+    prepare_empty_database(&state.connection_pool).await;
+    let app = create_app(state).await;
+    let listener = create_listener().await;
+    let server = axum::serve(listener, app).into_future();
+    tokio::spawn(server);
+
+    let tournament_id = get_id_of_a_new_tournament("test").await?;
+    let token = get_organizer_token(&tournament_id).await;
+    let debate_id = get_id_of_a_new_debate(&tournament_id).await?;
+
+    // WHEN
+    let response = get_debate(&debate_id, &tournament_id, &token).await;
+
+    // THEN
+    assert_eq!(response.status(), StatusCode::OK);
+
+    Ok(())
+}

--- a/tests/integration_tests/debates_tests.rs
+++ b/tests/integration_tests/debates_tests.rs
@@ -7,9 +7,9 @@ use tau::{omni_error::OmniError, setup};
 use crate::common::{
     create_app, create_listener,
     debates_utils::{get_debate, get_id_of_a_new_debate},
-    prepare_empty_database,
+    get_response_json, prepare_empty_database,
     tournament_utils::get_id_of_a_new_tournament,
-    user_utils::{get_id_of_a_new_user, get_organizer_token},
+    user_utils::get_organizer_token,
 };
 
 #[tokio::test]
@@ -34,6 +34,9 @@ async fn everyone_can_get_debate_details() -> Result<(), OmniError> {
 
     // THEN
     assert_eq!(response.status(), StatusCode::OK);
+
+    let response_body = get_response_json(response).await?;
+    assert_eq!(response_body["tournament_id"], tournament_id.to_string());
 
     Ok(())
 }

--- a/tests/integration_tests/main.rs
+++ b/tests/integration_tests/main.rs
@@ -1,10 +1,11 @@
 mod affiliations_tests;
 mod auth_tests;
 pub mod common;
+mod debates_tests;
 mod permissions_tests;
+mod plans_tests;
 mod roles_tests;
 mod teams_tests;
 mod teapot_tests;
 mod tournament_tests;
-mod plans_tests;
 mod verdicts_tests;

--- a/tests/integration_tests/verdicts_tests.rs
+++ b/tests/integration_tests/verdicts_tests.rs
@@ -9,7 +9,7 @@ use crate::common::{
     auth_utils::get_session_token_for,
     create_app, create_listener,
     debates_utils::get_id_of_a_new_debate,
-    prepare_empty_database,
+    get_response_json, prepare_empty_database,
     roles_utils::create_roles,
     tournament_utils::get_id_of_a_new_tournament,
     user_utils::{
@@ -55,18 +55,9 @@ async fn judges_should_be_able_to_make_verdicts_on_debates_within_their_tourname
     // THEN
     assert_eq!(response.status(), StatusCode::OK);
 
-    let response_body = response.json::<serde_json::Value>().await.unwrap();
-    assert_eq!(
-        response_body["judge_user_id"].as_str().unwrap().to_owned(),
-        judge_id.to_owned()
-    );
-    assert_eq!(
-        response_body["proposition_won"]
-            .as_bool()
-            .unwrap()
-            .to_owned(),
-        true
-    );
+    let response_body = get_response_json(response).await?;
+    assert_eq!(response_body["judge_user_id"], judge_id.to_owned());
+    assert_eq!(response_body["proposition_won"], true);
     Ok(())
 }
 
@@ -310,14 +301,8 @@ async fn judges_should_be_able_to_patch_verdicts() -> Result<(), OmniError> {
     // THEN
     assert_eq!(response.status(), StatusCode::OK);
 
-    let response_body = response.json::<serde_json::Value>().await.unwrap();
-    assert_eq!(
-        response_body["proposition_won"]
-            .as_bool()
-            .unwrap()
-            .to_owned(),
-        !initial_verdict
-    );
+    let response_body = get_response_json(response).await?;
+    assert_eq!(response_body["proposition_won"], !initial_verdict);
     Ok(())
 }
 


### PR DESCRIPTION
**Introduced changes**
- Fixed a syntax error in `debates_routes.rs` causing some of the endpoints to return 500 when providing two path params.
- Refactored and fixed formatting in a bunch of other files.

**Testing**
- [x] I have covered my code with tests.
- [x] I have run integration tests with `cargo test --tests` and ensured that they pass.
