### PR TITLE
fix: bump up cargo version in Dockerfile, test docker builds

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,3 +20,7 @@ jobs:
       run: cargo build --lib --verbose
     - name: Run tests
       run: cargo test --lib --verbose
+    - name: Build Docker image
+      run: docker build -t tau:test .
+    - name: Build Docker Compose
+      run: docker compose build server-prod

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG RUST_VERSION=1.83.0
+ARG RUST_VERSION=1.93.0
 ARG APP_NAME=tau
 
 FROM rust:${RUST_VERSION}-alpine AS build


### PR DESCRIPTION
**Introduced changes**
During frontend development, I stumbled upon `docker build` failing. I therefore resolved the issue and added CI steps to ensure that docker images are built properly.

**Testing**
- [x] I have covered my code with tests.
- [x] I have run integration tests with `cargo test --tests` and ensured that they pass.
