### PR TITLE
refactor: a new GET /tournament/{tournament_id}/ladder endpoint retur…

### DIFF
--- a/.sqlx/query-13644dc2b846bae73030417f682880ce73ed33aeb48dec6c4ce3818ed6f9cffd.json
+++ b/.sqlx/query-13644dc2b846bae73030417f682880ce73ed33aeb48dec6c4ce3818ed6f9cffd.json
@@ -1,0 +1,58 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id, name, tournament_id, is_finals, previous_phase_id, group_size, status\n            FROM phases\n            WHERE tournament_id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "tournament_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "is_finals",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 4,
+        "name": "previous_phase_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 5,
+        "name": "group_size",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 6,
+        "name": "status",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      false
+    ]
+  },
+  "hash": "13644dc2b846bae73030417f682880ce73ed33aeb48dec6c4ce3818ed6f9cffd"
+}

--- a/.sqlx/query-ea274d395c6af0bda06ecab5a89272f6df799720c46d9a04366a4d5b40838641.json
+++ b/.sqlx/query-ea274d395c6af0bda06ecab5a89272f6df799720c46d9a04366a4d5b40838641.json
@@ -1,0 +1,64 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                rounds.id,\n                rounds.name,\n                rounds.phase_id,\n                rounds.planned_start_time,\n                rounds.planned_end_time,\n                rounds.motion_id,\n                rounds.previous_round_id,\n                rounds.status\n            FROM rounds\n            JOIN phases ON phases.id = rounds.phase_id\n            WHERE phases.tournament_id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "phase_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "planned_start_time",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 4,
+        "name": "planned_end_time",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "motion_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 6,
+        "name": "previous_round_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 7,
+        "name": "status",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      false
+    ]
+  },
+  "hash": "ea274d395c6af0bda06ecab5a89272f6df799720c46d9a04366a4d5b40838641"
+}

--- a/src/routes/ladder_routes.rs
+++ b/src/routes/ladder_routes.rs
@@ -1,0 +1,83 @@
+use axum::{
+    extract::{Path, State},
+    http::HeaderMap,
+    response::{IntoResponse, Response},
+    routing::get,
+    Json, Router,
+};
+use serde::Serialize;
+use sqlx::query;
+use tower_cookies::Cookies;
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use crate::{
+    omni_error::OmniError,
+    setup::AppState,
+    tournaments::{
+        debates::Debate,
+        phases::Phase,
+        rounds::Round,
+        Tournament,
+    },
+    users::{permissions::Permission, TournamentUser},
+};
+
+#[derive(Serialize, ToSchema)]
+struct TournamentLadderResponse {
+    phases: Vec<Phase>,
+    rounds: Vec<Round>,
+    debates: Vec<Debate>,
+}
+
+pub fn route() -> Router<AppState> {
+    Router::new().route("/tournament/{tournament_id}/ladder", get(get_ladder))
+}
+
+#[utoipa::path(get, path = "/tournament/{tournament_id}/ladder",
+    responses(
+        (status=200, description = "Ok", body=TournamentLadderResponse),
+        (status=400, description = "Bad request"),
+        (status=401, description = "Authentication error"),
+        (status=403, description = "The user is not permitted to read this tournament ladder"),
+        (status=404, description = "Tournament not found"),
+        (status=500, description = "Internal server error")
+    ),
+    tag="tournaments"
+)]
+async fn get_ladder(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    cookies: Cookies,
+    Path(tournament_id): Path<Uuid>,
+) -> Result<Response, OmniError> {
+    let pool = &state.connection_pool;
+    let tournament_user =
+        TournamentUser::authenticate(tournament_id, &headers, cookies, pool).await?;
+
+    if !tournament_user.has_permission(Permission::ReadPhases)
+        || !tournament_user.has_permission(Permission::ReadRounds)
+        || !tournament_user.has_permission(Permission::ReadDebates)
+    {
+        return Err(OmniError::InsufficientPermissionsError);
+    }
+
+    let _tournament = Tournament::get_by_id(tournament_id, pool).await?;
+
+    let mut transaction = pool.begin().await?;
+    query("SET TRANSACTION READ ONLY")
+        .execute(&mut *transaction)
+        .await?;
+
+    let phases = Phase::get_all(tournament_id, &mut *transaction).await?;
+    let rounds = Round::get_all(tournament_id, &mut *transaction).await?;
+    let debates = Debate::get_all(tournament_id, &mut *transaction).await?;
+    transaction.commit().await?;
+
+    Ok(Json(TournamentLadderResponse {
+        phases,
+        rounds,
+        debates,
+    })
+    .into_response())
+}

--- a/src/routes/ladder_routes.rs
+++ b/src/routes/ladder_routes.rs
@@ -14,12 +14,7 @@ use uuid::Uuid;
 use crate::{
     omni_error::OmniError,
     setup::AppState,
-    tournaments::{
-        debates::Debate,
-        phases::Phase,
-        rounds::Round,
-        Tournament,
-    },
+    tournaments::{debates::Debate, phases::Phase, rounds::Round, Tournament},
     users::{permissions::Permission, TournamentUser},
 };
 

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -8,6 +8,7 @@ mod auth;
 mod debate_routes;
 mod health_check;
 mod infradmin_routes;
+mod ladder_routes;
 mod location_routes;
 mod motion_routes;
 mod permissions_routes;
@@ -31,6 +32,7 @@ pub fn routes() -> Router<AppState> {
         .merge(teapot::route())
         .merge(version::route())
         .merge(infradmin_routes::route())
+        .merge(ladder_routes::route())
         .merge(auth::route())
         .merge(tournament_routes::route())
         .merge(team_routes::route())

--- a/src/tournaments/debates.rs
+++ b/src/tournaments/debates.rs
@@ -1,6 +1,6 @@
 ﻿use serde::{Deserialize, Serialize};
 use serde_inline_default::serde_inline_default;
-use sqlx::{query, query_as, Pool, Postgres, Transaction};
+use sqlx::{query, query_as, Executor, Pool, Postgres, Transaction};
 use utoipa::ToSchema;
 use uuid::Uuid;
 
@@ -38,6 +38,24 @@ pub struct DebatePatch {
 }
 
 impl Debate {
+    pub async fn get_all<'e, E>(
+        tournament_id: Uuid,
+        executor: E,
+    ) -> Result<Vec<Debate>, OmniError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
+        let debates = query_as!(
+            Debate,
+            "SELECT * FROM debates WHERE tournament_id = $1",
+            tournament_id
+        )
+        .fetch_all(executor)
+        .await?;
+
+        Ok(debates)
+    }
+
     pub async fn post(
         tournament_id: Uuid,
         json: Debate,

--- a/src/tournaments/phases.rs
+++ b/src/tournaments/phases.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use axum::http::StatusCode;
 use serde::{Deserialize, Serialize};
 use serde_inline_default::serde_inline_default;
-use sqlx::{query, Pool, Postgres, Transaction};
+use sqlx::{query, Executor, Pool, Postgres, Transaction};
 use utoipa::ToSchema;
 use uuid::Uuid;
 
@@ -59,6 +59,40 @@ pub enum PhaseStatus {
 }
 
 impl Phase {
+    pub async fn get_all<'e, E>(
+        tournament_id: Uuid,
+        executor: E,
+    ) -> Result<Vec<Phase>, OmniError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
+        let records = query!(
+            r#"
+            SELECT id, name, tournament_id, is_finals, previous_phase_id, group_size, status
+            FROM phases
+            WHERE tournament_id = $1
+            "#,
+            tournament_id
+        )
+        .fetch_all(executor)
+        .await?;
+
+        let mut phases = Vec::with_capacity(records.len());
+        for record in records {
+            phases.push(Phase {
+                id: record.id,
+                name: record.name,
+                tournament_id: record.tournament_id,
+                is_finals: record.is_finals,
+                previous_phase_id: record.previous_phase_id,
+                group_size: record.group_size,
+                status: PhaseStatus::try_from(record.status)?,
+            });
+        }
+
+        Ok(phases)
+    }
+
     pub async fn post(
         tournament_id: Uuid,
         json: Phase,

--- a/src/tournaments/rounds.rs
+++ b/src/tournaments/rounds.rs
@@ -69,6 +69,50 @@ pub enum RoundStatus {
 }
 
 impl Round {
+    pub async fn get_all<'e, E>(
+        tournament_id: Uuid,
+        executor: E,
+    ) -> Result<Vec<Round>, OmniError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
+        let records = query!(
+            r#"
+            SELECT
+                rounds.id,
+                rounds.name,
+                rounds.phase_id,
+                rounds.planned_start_time,
+                rounds.planned_end_time,
+                rounds.motion_id,
+                rounds.previous_round_id,
+                rounds.status
+            FROM rounds
+            JOIN phases ON phases.id = rounds.phase_id
+            WHERE phases.tournament_id = $1
+            "#,
+            tournament_id
+        )
+        .fetch_all(executor)
+        .await?;
+
+        let mut rounds = Vec::with_capacity(records.len());
+        for record in records {
+            rounds.push(Round {
+                id: record.id,
+                name: record.name,
+                phase_id: record.phase_id,
+                planned_start_time: record.planned_start_time,
+                planned_end_time: record.planned_end_time,
+                motion_id: record.motion_id,
+                previous_round_id: record.previous_round_id,
+                status: RoundStatus::try_from(record.status)?,
+            });
+        }
+
+        Ok(rounds)
+    }
+
     pub async fn post(round: Round, pool: &Pool<Postgres>) -> Result<Round, OmniError> {
         let mut transaction = pool.begin().await?;
         let round = Self::post_with_transaction(&mut transaction, round).await?;

--- a/tests/integration_tests/ladder_tests.rs
+++ b/tests/integration_tests/ladder_tests.rs
@@ -38,10 +38,7 @@ async fn ladder_should_return_consistent_phases_rounds_and_debates(
 
     let ladder_response = app
         .client
-        .get(app.url(&format!(
-            "/tournament/{}/ladder",
-            tournament_id
-        )))
+        .get(app.url(&format!("/tournament/{}/ladder", tournament_id)))
         .bearer_auth(token)
         .send()
         .await

--- a/tests/integration_tests/ladder_tests.rs
+++ b/tests/integration_tests/ladder_tests.rs
@@ -1,0 +1,114 @@
+use std::collections::HashSet;
+
+use reqwest::StatusCode;
+use tau::omni_error::OmniError;
+
+use crate::common::{
+    plans_utils::{
+        calculate_final_phase_debates, calculate_final_phase_rounds, create_plan,
+    },
+    test_app::TestApp,
+    tournament_utils::get_id_of_a_new_tournament,
+    user_utils::get_organizer_token,
+};
+
+const TEST_GROUP_PHASE_ROUNDS: i32 = 4;
+const TEST_GROUPS_COUNT: i32 = 8;
+const TEST_ADVANCING_TEAMS: i32 = 4;
+const TEST_TOTAL_TEAMS: i32 = 32;
+
+#[tokio::test]
+async fn ladder_should_return_consistent_phases_rounds_and_debates(
+) -> Result<(), OmniError> {
+    let app = TestApp::spawn().await;
+    let tournament_id = get_id_of_a_new_tournament(&app, "ladder").await?;
+    let token = get_organizer_token(&app, &tournament_id).await;
+
+    let plan_response = create_plan(
+        &app,
+        &tournament_id,
+        TEST_ADVANCING_TEAMS,
+        TEST_GROUP_PHASE_ROUNDS,
+        TEST_GROUPS_COUNT,
+        TEST_TOTAL_TEAMS,
+        &token,
+    )
+    .await;
+    assert_eq!(plan_response.status(), StatusCode::OK);
+
+    let ladder_response = app
+        .client
+        .get(app.url(&format!(
+            "/tournament/{}/ladder",
+            tournament_id
+        )))
+        .bearer_auth(token)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(ladder_response.status(), StatusCode::OK);
+    let body = ladder_response.json::<serde_json::Value>().await.unwrap();
+
+    let phases = body["phases"]
+        .as_array()
+        .expect("phases should be an array");
+    let rounds = body["rounds"]
+        .as_array()
+        .expect("rounds should be an array");
+    let debates = body["debates"]
+        .as_array()
+        .expect("debates should be an array");
+
+    let expected_phase_count = 2usize;
+    let expected_round_count = (TEST_GROUP_PHASE_ROUNDS
+        + calculate_final_phase_rounds(TEST_ADVANCING_TEAMS))
+        as usize;
+    let expected_debate_count = (TEST_GROUPS_COUNT * TEST_GROUP_PHASE_ROUNDS
+        + calculate_final_phase_debates(TEST_ADVANCING_TEAMS))
+        as usize;
+
+    assert_eq!(phases.len(), expected_phase_count);
+    assert_eq!(rounds.len(), expected_round_count);
+    assert_eq!(debates.len(), expected_debate_count);
+
+    let phase_ids: HashSet<&str> = phases
+        .iter()
+        .map(|phase| {
+            phase["id"]
+                .as_str()
+                .expect("every phase should have string id")
+        })
+        .collect();
+
+    let round_ids: HashSet<&str> = rounds
+        .iter()
+        .map(|round| {
+            round["id"]
+                .as_str()
+                .expect("every round should have string id")
+        })
+        .collect();
+
+    for round in rounds {
+        let parent_phase_id = round["phase_id"]
+            .as_str()
+            .expect("every round should have phase_id");
+        assert!(
+            phase_ids.contains(parent_phase_id),
+            "round refers to missing phase_id {parent_phase_id}"
+        );
+    }
+
+    for debate in debates {
+        let parent_round_id = debate["round_id"]
+            .as_str()
+            .expect("every debate should have round_id");
+        assert!(
+            round_ids.contains(parent_round_id),
+            "debate refers to missing round_id {parent_round_id}"
+        );
+    }
+
+    Ok(())
+}

--- a/tests/integration_tests/main.rs
+++ b/tests/integration_tests/main.rs
@@ -2,6 +2,7 @@
 mod auth_tests;
 pub mod common;
 mod debates_tests;
+mod ladder_tests;
 mod permissions_tests;
 mod plans_tests;
 mod roles_tests;


### PR DESCRIPTION
**Introduced changes**
I created a new GET /tournament/{tournament_id}/ladder endpoint returning a JSON containing information about all phases, rounds, and debates of a tournament. I also expanded implementation of struct for debates.rs file with methods to get all entities. I also planned the tournaments with /plan endpoint and used /ladder and checked for referential integrity (both parent round and phase are also present in the response body).

**Testing**
- Newly introduced cargo fmt and cargo clippy methods are applied, code compiles without any bug.
- [x] I have covered my code with tests. (this can be verified by observing that total number of tests are increased from 50 to 51 for cargo test command.)
- [x] I have run integration tests with `cargo test --tests` and ensured that they pass.
