### PR TITLE
Scrum 88 ladder endpoint documentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3099,7 +3099,7 @@ dependencies = [
 
 [[package]]
 name = "tau"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "argon2",
  "aws-lc-rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3099,7 +3099,7 @@ dependencies = [
 
 [[package]]
 name = "tau"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "argon2",
  "aws-lc-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tau"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 repository = "https://github.com/debatecore/tau"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tau"
-version = "0.1.1"
+version = "0.1.2"
 description = "A project for versioning python-based tau development utils"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/routes/ladder_routes.rs
+++ b/src/routes/ladder_routes.rs
@@ -26,12 +26,13 @@ struct TournamentLadderResponse {
 }
 
 pub fn route() -> Router<AppState> {
-    Router::new().route("/tournament/{tournament_id}/ladder", get(get_ladder))
+    Router::new().route("/tournaments/{tournament_id}/ladder", get(get_ladder))
 }
 
-#[utoipa::path(get, path = "/tournament/{tournament_id}/ladder",
+#[utoipa::path(get, path = "/tournaments/{tournament_id}/ladder",
+    description = "Returns the tournament ladder including all phases, rounds, and debates for the specified tournament. Requires authentication and tournament permissions ReadPhases, ReadRounds, and ReadDebates.",
     responses(
-        (status=200, description = "Ok", body=TournamentLadderResponse),
+        (status=200, description = "Tournament ladder returned successfully", body=TournamentLadderResponse),
         (status=400, description = "Bad request"),
         (status=401, description = "Authentication error"),
         (status=403, description = "The user is not permitted to read this tournament ladder"),

--- a/src/routes/swagger.rs
+++ b/src/routes/swagger.rs
@@ -9,6 +9,7 @@ use crate::setup::AppState;
 use crate::routes::affiliation_routes;
 use crate::routes::attendee_routes;
 use crate::routes::debate_routes;
+use crate::routes::ladder_routes;
 use crate::routes::location_routes;
 use crate::routes::motion_routes;
 use crate::routes::permissions_routes;
@@ -20,7 +21,6 @@ use crate::routes::round_routes;
 use crate::routes::team_routes;
 use crate::routes::tournament_routes;
 use crate::routes::verdicts_routes;
-use crate::routes::ladder_routes;
 
 use crate::tournaments;
 use crate::tournaments::affiliations;

--- a/src/routes/swagger.rs
+++ b/src/routes/swagger.rs
@@ -20,6 +20,7 @@ use crate::routes::round_routes;
 use crate::routes::team_routes;
 use crate::routes::tournament_routes;
 use crate::routes::verdicts_routes;
+use crate::routes::ladder_routes;
 
 use crate::tournaments;
 use crate::tournaments::affiliations;
@@ -69,6 +70,7 @@ pub fn route() -> Router<AppState> {
         motion_routes::get_motion_by_id,
         motion_routes::patch_motion_by_id,
         motion_routes::delete_motion_by_id,
+        ladder_routes::get_ladder,
         team_routes::get_teams,
         team_routes::create_team,
         team_routes::get_team_by_id,

--- a/tests/integration_tests/ladder_tests.rs
+++ b/tests/integration_tests/ladder_tests.rs
@@ -38,7 +38,7 @@ async fn ladder_should_return_consistent_phases_rounds_and_debates(
 
     let ladder_response = app
         .client
-        .get(app.url(&format!("/tournament/{}/ladder", tournament_id)))
+        .get(app.url(&format!("/tournaments/{}/ladder", tournament_id)))
         .bearer_auth(token)
         .send()
         .await


### PR DESCRIPTION
**Introduced changes**

ladder_routes.rs -> Renamed route from /tournament/{tournament_id}/ladder to /tournaments/{tournament_id}/ladder

Added Utoipa description documenting:
-What the endpoint returns
-Authentication requirement
- Required permissions (ReadPhases, ReadRounds, ReadDebates)
- Kept response status codes with clear meanings

swagger.rs -> Added ladder_routes::get_ladder to the generated OpenAPI pathlist so the endpoint is included in Swagger/OpenAPI output

ladder_tests.rs -> Updated the test to call /tournaments/{tournament_id}/ladder

**Validation**
cargo check command completed successfully. 


**Testing**
- [x] I have run integration tests with `cargo test --tests` and ensured that they pass.
- [x] cargo clippy and cargo fmt commands are passed without any issue.
