### PR TITLE
fixed the bug with null previous round id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3099,7 +3099,7 @@ dependencies = [
 
 [[package]]
 name = "tau"
-version = "0.1.0"
+version = "0.1.3"
 dependencies = [
  "argon2",
  "aws-lc-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tau"
-version = "0.1.0"
+version = "0.1.3"
 edition = "2021"
 repository = "https://github.com/debatecore/tau"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tau"
-version = "0.1.0"
+version = "0.1.3"
 description = "A project for versioning python-based tau development utils"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/tournaments/plans.rs
+++ b/src/tournaments/plans.rs
@@ -236,10 +236,11 @@ impl TournamentPlan {
 
         // Phase
         let mut previous_phase_id: Option<Uuid> = None;
+        let mut previous_round_id: Option<Uuid> = None;
 
         for phase_index in 1..=2 {
             let curr_phase_id = Uuid::now_v7();
-            let is_finals = phase_index == 2; // is phase count constant (group phase / final phase)?
+            let is_finals = phase_index == 2;
 
             Phase::post_with_transaction(
                 transaction,
@@ -255,8 +256,6 @@ impl TournamentPlan {
                 },
             )
             .await?;
-
-            let mut previous_round_id: Option<Uuid> = None;
 
             // Group phase
             if !is_finals {

--- a/tests/integration_tests/ladder_tests.rs
+++ b/tests/integration_tests/ladder_tests.rs
@@ -109,3 +109,101 @@ async fn ladder_should_return_consistent_phases_rounds_and_debates(
 
     Ok(())
 }
+
+#[tokio::test]
+async fn ladder_rounds_should_form_single_previous_round_chain() -> Result<(), OmniError> {
+    let app = TestApp::spawn().await;
+    let tournament_id = get_id_of_a_new_tournament(&app, "ladder").await?;
+    let token = get_organizer_token(&app, &tournament_id).await;
+
+    let plan_response = create_plan(
+        &app,
+        &tournament_id,
+        TEST_ADVANCING_TEAMS,
+        TEST_GROUP_PHASE_ROUNDS,
+        TEST_GROUPS_COUNT,
+        TEST_TOTAL_TEAMS,
+        &token,
+    )
+    .await;
+
+    assert_eq!(plan_response.status(), StatusCode::OK);
+
+    let ladder_response = app
+        .client
+        .get(app.url(&format!("/tournament/{}/ladder", tournament_id)))
+        .bearer_auth(token)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(ladder_response.status(), StatusCode::OK);
+
+    let body = ladder_response.json::<serde_json::Value>().await.unwrap();
+
+    let rounds = body["rounds"]
+        .as_array()
+        .expect("rounds should be an array");
+
+    let first_rounds: Vec<&serde_json::Value> = rounds
+        .iter()
+        .filter(|round| round["previous_round_id"].is_null())
+        .collect();
+
+    assert_eq!(
+        first_rounds.len(),
+        1,
+        "exactly one round should have no previous_round_id"
+    );
+
+    let mut sorted_rounds = vec![first_rounds[0]];
+    let mut used_round_ids: HashSet<&str> = HashSet::new();
+
+    let first_round_id = first_rounds[0]["id"]
+        .as_str()
+        .expect("first round should have string id");
+
+    used_round_ids.insert(first_round_id);
+
+    while sorted_rounds.len() < rounds.len() {
+        let previous_round_id = sorted_rounds
+            .last()
+            .unwrap()["id"]
+            .as_str()
+            .expect("every sorted round should have string id");
+
+        let next_rounds: Vec<&serde_json::Value> = rounds
+            .iter()
+            .filter(|round| {
+                let round_id = round["id"]
+                    .as_str()
+                    .expect("every round should have string id");
+
+                !used_round_ids.contains(round_id)
+                    && round["previous_round_id"].as_str() == Some(previous_round_id)
+            })
+            .collect();
+
+        assert_eq!(
+            next_rounds.len(),
+            1,
+            "expected exactly one next round after round {previous_round_id}"
+        );
+
+        let next_round = next_rounds[0];
+        let next_round_id = next_round["id"]
+            .as_str()
+            .expect("next round should have string id");
+
+        used_round_ids.insert(next_round_id);
+        sorted_rounds.push(next_round);
+    }
+
+    assert_eq!(
+        sorted_rounds.len(),
+        rounds.len(),
+        "sorted rounds chain should contain every round returned by ladder"
+    );
+
+    Ok(())
+}

--- a/tests/integration_tests/ladder_tests.rs
+++ b/tests/integration_tests/ladder_tests.rs
@@ -111,7 +111,8 @@ async fn ladder_should_return_consistent_phases_rounds_and_debates(
 }
 
 #[tokio::test]
-async fn ladder_rounds_should_form_single_previous_round_chain() -> Result<(), OmniError> {
+async fn ladder_rounds_should_form_single_previous_round_chain() -> Result<(), OmniError>
+{
     let app = TestApp::spawn().await;
     let tournament_id = get_id_of_a_new_tournament(&app, "ladder").await?;
     let token = get_organizer_token(&app, &tournament_id).await;
@@ -166,9 +167,7 @@ async fn ladder_rounds_should_form_single_previous_round_chain() -> Result<(), O
     used_round_ids.insert(first_round_id);
 
     while sorted_rounds.len() < rounds.len() {
-        let previous_round_id = sorted_rounds
-            .last()
-            .unwrap()["id"]
+        let previous_round_id = sorted_rounds.last().unwrap()["id"]
             .as_str()
             .expect("every sorted round should have string id");
 


### PR DESCRIPTION
**Fixed the bug with null previous round id**
- Modified: `plans.rs`
- Modified: `ladder_tests.rs` (added consistency test)

**Testing**
- [x] I have covered my fix with tests.
- [x] I have run integration tests with `cargo test --tests` and ensured that they pass.
