### PR TITLE
Automated tournament shortened name derivation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3117,7 +3117,7 @@ dependencies = [
 
 [[package]]
 name = "tau"
-version = "0.1.5"
+version = "0.1.7"
 dependencies = [
  "argon2",
  "aws-lc-rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3117,7 +3117,7 @@ dependencies = [
 
 [[package]]
 name = "tau"
-version = "0.1.7"
+version = "0.1.10"
 dependencies = [
  "argon2",
  "aws-lc-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tau"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 repository = "https://github.com/debatecore/tau"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tau"
-version = "0.1.7"
+version = "0.1.10"
 edition = "2021"
 repository = "https://github.com/debatecore/tau"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tau"
-version = "0.1.6"
+version = "0.1.7"
 description = "A project for versioning python-based tau development utils"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tau"
-version = "0.1.7"
+version = "0.1.10"
 description = "A project for versioning python-based tau development utils"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/tournaments/mod.rs
+++ b/src/tournaments/mod.rs
@@ -9,6 +9,8 @@ use teams::Team;
 use tracing::error;
 use utoipa::ToSchema;
 use uuid::Uuid;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::omni_error::OmniError;
 
@@ -34,6 +36,8 @@ static DEFAULT_DEBATE_PREPARATION_TIME: i32 = 15;
 static DEFAULT_BEEP_ON_SPEECH_END: bool = true;
 static DEFAULT_BEEP_ON_PROTECTED_TIME: bool = true;
 static DEFAULT_VISUALIZE_PROTECTED_TIME: bool = false;
+
+static COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// Represents a tournament.
 ///
@@ -142,7 +146,7 @@ impl Tournament {
                 visualize_protected_time"#,
             tournament.id,
             tournament.full_name,
-            tournament.shortened_name,
+            shorten(&tournament.full_name),
             tournament.speech_time.unwrap_or(DEFAULT_SPEECH_TIME),
             tournament
                 .end_protected_time
@@ -206,10 +210,11 @@ impl Tournament {
         patch: TournamentPatch,
         pool: &Pool<Postgres>,
     ) -> Result<Tournament, OmniError> {
+        let name = patch.full_name.unwrap_or(self.full_name);
         let tournament = Tournament {
             id: self.id,
-            full_name: patch.full_name.unwrap_or(self.full_name),
-            shortened_name: patch.shortened_name.unwrap_or(self.shortened_name),
+            full_name: name.clone(),
+            shortened_name: shorten(&name),
             speech_time: patch.speech_time,
             end_protected_time: patch.end_protected_time,
             start_protected_time: patch.start_protected_time,
@@ -366,5 +371,67 @@ impl Tournament {
             phases.push(phase);
         }
         Ok(phases)
+    }
+}
+
+fn shorten(word: &str) -> String {
+    let len = word.chars().count();
+    let id = short_id();
+
+    if len <= 5 {
+        return capitalize(&format!("{}{}", word, id));
+    }
+
+    let first = word.chars().next().unwrap();
+    let last = word.chars().last().unwrap();
+
+    capitalize(&format!(
+        "{}{}{}{}",
+        first,
+        len - 2,
+        last,
+        id
+    ))
+}
+
+fn short_id() -> String {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+
+    let count = COUNTER.fetch_add(1, Ordering::Relaxed) as u128;
+
+    let value = now ^ count;
+
+    base36(value % 1679616) // 36^4 = 4 chars
+}
+
+fn base36(mut value: u128) -> String {
+    const CHARS: &[u8] = b"0123456789abcdefghijklmnopqrstuvwxyz";
+
+    if value == 0 {
+        return "0".to_string();
+    }
+
+    let mut result = Vec::new();
+
+    while value > 0 {
+        let index = (value % 36) as usize;
+        result.push(CHARS[index] as char);
+        value /= 36;
+    }
+
+    result.iter().rev().collect()
+}
+
+fn capitalize(word: &str) -> String {
+    let mut chars = word.chars();
+
+    match chars.next() {
+        None => String::new(),
+        Some(first) => {
+            first.to_uppercase().collect::<String>() + chars.as_str()
+        }
     }
 }

--- a/src/tournaments/mod.rs
+++ b/src/tournaments/mod.rs
@@ -81,7 +81,7 @@ pub struct Tournament {
 pub struct TournamentPatch {
     /// Full name of the tournament. Must be unique.
     full_name: Option<String>,
-    shortened_name: Option<String>,
+    // shortened_name: Option<String>,
     /// In seconds
     /// Speech time per speaker during a debate in seconds.
     speech_time: Option<i32>,

--- a/src/tournaments/mod.rs
+++ b/src/tournaments/mod.rs
@@ -406,4 +406,3 @@ pub fn shorten(name: &str) -> String {
 
     result.to_uppercase()
 }
-

--- a/src/tournaments/mod.rs
+++ b/src/tournaments/mod.rs
@@ -375,7 +375,7 @@ impl Tournament {
     }
 }
 
-fn shorten(name: &str) -> String {
+pub fn shorten(name: &str) -> String {
     let words: Vec<String> = name
         .split_whitespace()
         .map(|word| {
@@ -404,14 +404,6 @@ fn shorten(name: &str) -> String {
         }
     }
 
-    capitalize(&result)
+    result.to_uppercase()
 }
 
-fn capitalize(word: &str) -> String {
-    let mut chars = word.chars();
-
-    match chars.next() {
-        None => String::new(),
-        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
-    }
-}

--- a/src/tournaments/mod.rs
+++ b/src/tournaments/mod.rs
@@ -5,12 +5,12 @@ use plans::TournamentPlan;
 use rounds::Round;
 use serde::{Deserialize, Serialize};
 use sqlx::{query, query_as, Pool, Postgres};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
 use teams::Team;
 use tracing::error;
 use utoipa::ToSchema;
 use uuid::Uuid;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::omni_error::OmniError;
 
@@ -385,13 +385,7 @@ fn shorten(word: &str) -> String {
     let first = word.chars().next().unwrap();
     let last = word.chars().last().unwrap();
 
-    capitalize(&format!(
-        "{}{}{}{}",
-        first,
-        len - 2,
-        last,
-        id
-    ))
+    capitalize(&format!("{}{}{}{}", first, len - 2, last, id))
 }
 
 fn short_id() -> String {
@@ -430,8 +424,6 @@ fn capitalize(word: &str) -> String {
 
     match chars.next() {
         None => String::new(),
-        Some(first) => {
-            first.to_uppercase().collect::<String>() + chars.as_str()
-        }
+        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
     }
 }

--- a/src/tournaments/mod.rs
+++ b/src/tournaments/mod.rs
@@ -5,8 +5,6 @@ use plans::TournamentPlan;
 use rounds::Round;
 use serde::{Deserialize, Serialize};
 use sqlx::{query, query_as, Pool, Postgres};
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{SystemTime, UNIX_EPOCH};
 use teams::Team;
 use tracing::error;
 use utoipa::ToSchema;
@@ -36,8 +34,6 @@ static DEFAULT_DEBATE_PREPARATION_TIME: i32 = 15;
 static DEFAULT_BEEP_ON_SPEECH_END: bool = true;
 static DEFAULT_BEEP_ON_PROTECTED_TIME: bool = true;
 static DEFAULT_VISUALIZE_PROTECTED_TIME: bool = false;
-
-static COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// Represents a tournament.
 ///
@@ -81,7 +77,7 @@ pub struct Tournament {
 pub struct TournamentPatch {
     /// Full name of the tournament. Must be unique.
     full_name: Option<String>,
-    // shortened_name: Option<String>,
+    shortened_name: Option<String>,
     /// In seconds
     /// Speech time per speaker during a debate in seconds.
     speech_time: Option<i32>,
@@ -114,6 +110,10 @@ impl Tournament {
         tournament: Tournament,
         pool: &Pool<Postgres>,
     ) -> Result<Tournament, OmniError> {
+        let mut shortened_name = tournament.shortened_name.clone();
+        if tournament.shortened_name == "" {
+            shortened_name = shorten(&tournament.full_name);
+        }
         match query_as!(
             Tournament,
             r#"INSERT INTO tournaments
@@ -146,7 +146,7 @@ impl Tournament {
                 visualize_protected_time"#,
             tournament.id,
             tournament.full_name,
-            shorten(&tournament.full_name),
+            shortened_name,
             tournament.speech_time.unwrap_or(DEFAULT_SPEECH_TIME),
             tournament
                 .end_protected_time
@@ -211,10 +211,11 @@ impl Tournament {
         pool: &Pool<Postgres>,
     ) -> Result<Tournament, OmniError> {
         let name = patch.full_name.unwrap_or(self.full_name);
+        let shortened = patch.shortened_name.unwrap_or(shorten(&name));
         let tournament = Tournament {
             id: self.id,
             full_name: name.clone(),
-            shortened_name: shorten(&name),
+            shortened_name: shortened.clone(),
             speech_time: patch.speech_time,
             end_protected_time: patch.end_protected_time,
             start_protected_time: patch.start_protected_time,
@@ -374,49 +375,36 @@ impl Tournament {
     }
 }
 
-fn shorten(word: &str) -> String {
-    let len = word.chars().count();
-    let id = short_id();
+fn shorten(name: &str) -> String {
+    let words: Vec<String> = name
+        .split_whitespace()
+        .map(|word| {
+            word.chars()
+                .filter(|c| c.is_alphabetic())
+                .collect::<String>()
+        })
+        .filter(|word| !word.is_empty())
+        .collect();
 
-    if len <= 5 {
-        return capitalize(&format!("{}{}", word, id));
+    let mut result = String::new();
+
+    match words.len() {
+        0 => {}
+        1 => {
+            result.extend(words[0].chars().take(3));
+        }
+        2 => {
+            result.extend(words[0].chars().take(2));
+            result.extend(words[1].chars().take(1));
+        }
+        _ => {
+            for word in words.iter().take(3) {
+                result.extend(word.chars().take(1));
+            }
+        }
     }
 
-    let first = word.chars().next().unwrap();
-    let last = word.chars().last().unwrap();
-
-    capitalize(&format!("{}{}{}{}", first, len - 2, last, id))
-}
-
-fn short_id() -> String {
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-
-    let count = COUNTER.fetch_add(1, Ordering::Relaxed) as u128;
-
-    let value = now ^ count;
-
-    base36(value % 1679616) // 36^4 = 4 chars
-}
-
-fn base36(mut value: u128) -> String {
-    const CHARS: &[u8] = b"0123456789abcdefghijklmnopqrstuvwxyz";
-
-    if value == 0 {
-        return "0".to_string();
-    }
-
-    let mut result = Vec::new();
-
-    while value > 0 {
-        let index = (value % 36) as usize;
-        result.push(CHARS[index] as char);
-        value /= 36;
-    }
-
-    result.iter().rev().collect()
+    capitalize(&result)
 }
 
 fn capitalize(word: &str) -> String {

--- a/src/tournaments/mod.rs
+++ b/src/tournaments/mod.rs
@@ -111,7 +111,7 @@ impl Tournament {
         pool: &Pool<Postgres>,
     ) -> Result<Tournament, OmniError> {
         let mut shortened_name = tournament.shortened_name.clone();
-        if tournament.shortened_name == "" {
+        if tournament.shortened_name.is_empty() {
             shortened_name = shorten(&tournament.full_name);
         }
         match query_as!(

--- a/tests/integration_tests/common/tournament_utils.rs
+++ b/tests/integration_tests/common/tournament_utils.rs
@@ -3,20 +3,59 @@ use std::collections::HashMap;
 use reqwest::{Response, StatusCode};
 use tau::omni_error::OmniError;
 
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{SystemTime, UNIX_EPOCH};
-
 use crate::common::{
     auth_utils::get_session_token_for_infrastructure_admin, test_app::TestApp,
 };
 
-static COUNTER: AtomicU64 = AtomicU64::new(0);
+pub async fn create_tournament(
+    app: &TestApp,
+    full_name: &str,
+    shortened_name: Option<std::string::String>,
+    token: &str,
+) -> Response {
+    if shortened_name == None {
+        return create_tournament_without_shortened_name(app, full_name, token).await;
+    } else {
+        return create_tournament_with_shortened_name(
+            app,
+            full_name,
+            &shortened_name.unwrap_or(shorten(full_name)),
+            token,
+        )
+        .await;
+    }
+}
 
-pub async fn create_tournament(app: &TestApp, full_name: &str, token: &str) -> Response {
+pub async fn create_tournament_without_shortened_name(
+    app: &TestApp,
+    full_name: &str,
+    token: &str,
+) -> Response {
     let mut request_body = HashMap::new();
     request_body.insert("full_name", full_name);
     let shortened = shorten(&full_name);
     request_body.insert("shortened_name", &shortened);
+
+    app.client
+        .post(app.url("/tournaments"))
+        .json(&request_body)
+        .header("accept", "text/plain")
+        .header("Content-Type", "application/json")
+        .bearer_auth(token)
+        .send()
+        .await
+        .unwrap()
+}
+
+pub async fn create_tournament_with_shortened_name(
+    app: &TestApp,
+    full_name: &str,
+    shortened_name: &str,
+    token: &str,
+) -> Response {
+    let mut request_body = HashMap::new();
+    request_body.insert("full_name", full_name);
+    request_body.insert("shortened_name", shortened_name);
 
     app.client
         .post(app.url("/tournaments"))
@@ -34,7 +73,7 @@ pub async fn get_id_of_a_new_tournament(
     full_name: &str,
 ) -> Result<String, OmniError> {
     let token = get_session_token_for_infrastructure_admin(app).await;
-    let response = create_tournament(app, full_name, &token).await;
+    let response = create_tournament(app, full_name, None, &token).await;
 
     match response.status() {
         StatusCode::OK => Ok(response.json::<serde_json::Value>().await.unwrap()["id"]
@@ -52,49 +91,36 @@ pub async fn get_id_of_a_new_tournament(
     }
 }
 
-fn shorten(word: &str) -> String {
-    let len = word.chars().count();
-    let id = short_id();
+fn shorten(name: &str) -> String {
+    let words: Vec<String> = name
+        .split_whitespace()
+        .map(|word| {
+            word.chars()
+                .filter(|c| c.is_alphabetic())
+                .collect::<String>()
+        })
+        .filter(|word| !word.is_empty())
+        .collect();
 
-    if len <= 5 {
-        return capitalize(&format!("{}{}", word, id));
+    let mut result = String::new();
+
+    match words.len() {
+        0 => {}
+        1 => {
+            result.extend(words[0].chars().take(3));
+        }
+        2 => {
+            result.extend(words[0].chars().take(2));
+            result.extend(words[1].chars().take(1));
+        }
+        _ => {
+            for word in words.iter().take(3) {
+                result.extend(word.chars().take(1));
+            }
+        }
     }
 
-    let first = word.chars().next().unwrap();
-    let last = word.chars().last().unwrap();
-
-    capitalize(&format!("{}{}{}{}", first, len - 2, last, id))
-}
-
-fn short_id() -> String {
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-
-    let count = COUNTER.fetch_add(1, Ordering::Relaxed) as u128;
-
-    let value = now ^ count;
-
-    base36(value % 1679616) // 36^4, gives up to 4 chars
-}
-
-fn base36(mut value: u128) -> String {
-    const CHARS: &[u8] = b"0123456789abcdefghijklmnopqrstuvwxyz";
-
-    if value == 0 {
-        return "0".to_string();
-    }
-
-    let mut result = Vec::new();
-
-    while value > 0 {
-        let index = (value % 36) as usize;
-        result.push(CHARS[index] as char);
-        value /= 36;
-    }
-
-    result.iter().rev().collect()
+    capitalize(&result)
 }
 
 fn capitalize(word: &str) -> String {

--- a/tests/integration_tests/common/tournament_utils.rs
+++ b/tests/integration_tests/common/tournament_utils.rs
@@ -12,11 +12,7 @@ use crate::common::{
 
 static COUNTER: AtomicU64 = AtomicU64::new(0);
 
-pub async fn create_tournament(
-    app: &TestApp,
-    full_name: &str,
-    token: &str,
-) -> Response {
+pub async fn create_tournament(app: &TestApp, full_name: &str, token: &str) -> Response {
     let mut request_body = HashMap::new();
     request_body.insert("full_name", full_name);
     let shortened = shorten(&full_name);
@@ -38,9 +34,7 @@ pub async fn get_id_of_a_new_tournament(
     full_name: &str,
 ) -> Result<String, OmniError> {
     let token = get_session_token_for_infrastructure_admin(app).await;
-    let response =
-        create_tournament(app, full_name, &token)
-            .await;
+    let response = create_tournament(app, full_name, &token).await;
 
     match response.status() {
         StatusCode::OK => Ok(response.json::<serde_json::Value>().await.unwrap()["id"]
@@ -69,13 +63,7 @@ fn shorten(word: &str) -> String {
     let first = word.chars().next().unwrap();
     let last = word.chars().last().unwrap();
 
-    capitalize(&format!(
-        "{}{}{}{}",
-        first,
-        len - 2,
-        last,
-        id
-    ))
+    capitalize(&format!("{}{}{}{}", first, len - 2, last, id))
 }
 
 fn short_id() -> String {
@@ -114,8 +102,6 @@ fn capitalize(word: &str) -> String {
 
     match chars.next() {
         None => String::new(),
-        Some(first) => {
-            first.to_uppercase().collect::<String>() + chars.as_str()
-        }
+        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
     }
 }

--- a/tests/integration_tests/common/tournament_utils.rs
+++ b/tests/integration_tests/common/tournament_utils.rs
@@ -3,19 +3,24 @@ use std::collections::HashMap;
 use reqwest::{Response, StatusCode};
 use tau::omni_error::OmniError;
 
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
 use crate::common::{
     auth_utils::get_session_token_for_infrastructure_admin, test_app::TestApp,
 };
 
+static COUNTER: AtomicU64 = AtomicU64::new(0);
+
 pub async fn create_tournament(
     app: &TestApp,
     full_name: &str,
-    shortened_name: &str,
     token: &str,
 ) -> Response {
     let mut request_body = HashMap::new();
     request_body.insert("full_name", full_name);
-    request_body.insert("shortened_name", shortened_name);
+    let shortened = shorten(&full_name);
+    request_body.insert("shortened_name", &shortened);
 
     app.client
         .post(app.url("/tournaments"))
@@ -34,7 +39,7 @@ pub async fn get_id_of_a_new_tournament(
 ) -> Result<String, OmniError> {
     let token = get_session_token_for_infrastructure_admin(app).await;
     let response =
-        create_tournament(app, full_name, &full_name[0..full_name.len() / 5], &token)
+        create_tournament(app, full_name, &token)
             .await;
 
     match response.status() {
@@ -50,5 +55,67 @@ pub async fn get_id_of_a_new_tournament(
                 response.text().await.unwrap(),
             ),
         }),
+    }
+}
+
+fn shorten(word: &str) -> String {
+    let len = word.chars().count();
+    let id = short_id();
+
+    if len <= 5 {
+        return capitalize(&format!("{}{}", word, id));
+    }
+
+    let first = word.chars().next().unwrap();
+    let last = word.chars().last().unwrap();
+
+    capitalize(&format!(
+        "{}{}{}{}",
+        first,
+        len - 2,
+        last,
+        id
+    ))
+}
+
+fn short_id() -> String {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+
+    let count = COUNTER.fetch_add(1, Ordering::Relaxed) as u128;
+
+    let value = now ^ count;
+
+    base36(value % 1679616) // 36^4, gives up to 4 chars
+}
+
+fn base36(mut value: u128) -> String {
+    const CHARS: &[u8] = b"0123456789abcdefghijklmnopqrstuvwxyz";
+
+    if value == 0 {
+        return "0".to_string();
+    }
+
+    let mut result = Vec::new();
+
+    while value > 0 {
+        let index = (value % 36) as usize;
+        result.push(CHARS[index] as char);
+        value /= 36;
+    }
+
+    result.iter().rev().collect()
+}
+
+fn capitalize(word: &str) -> String {
+    let mut chars = word.chars();
+
+    match chars.next() {
+        None => String::new(),
+        Some(first) => {
+            first.to_uppercase().collect::<String>() + chars.as_str()
+        }
     }
 }

--- a/tests/integration_tests/common/tournament_utils.rs
+++ b/tests/integration_tests/common/tournament_utils.rs
@@ -7,6 +7,8 @@ use crate::common::{
     auth_utils::get_session_token_for_infrastructure_admin, test_app::TestApp,
 };
 
+use tau::tournaments::shorten;
+
 pub async fn create_tournament(
     app: &TestApp,
     full_name: &str,
@@ -91,43 +93,14 @@ pub async fn get_id_of_a_new_tournament(
     }
 }
 
-fn shorten(name: &str) -> String {
-    let words: Vec<String> = name
-        .split_whitespace()
-        .map(|word| {
-            word.chars()
-                .filter(|c| c.is_alphabetic())
-                .collect::<String>()
-        })
-        .filter(|word| !word.is_empty())
-        .collect();
-
-    let mut result = String::new();
-
-    match words.len() {
-        0 => {}
-        1 => {
-            result.extend(words[0].chars().take(3));
-        }
-        2 => {
-            result.extend(words[0].chars().take(2));
-            result.extend(words[1].chars().take(1));
-        }
-        _ => {
-            for word in words.iter().take(3) {
-                result.extend(word.chars().take(1));
-            }
-        }
-    }
-
-    capitalize(&result)
-}
-
-fn capitalize(word: &str) -> String {
-    let mut chars = word.chars();
-
-    match chars.next() {
-        None => String::new(),
-        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+#[cfg(test)]
+mod test_shortened_name {
+    use tau::tournaments::shorten;
+    #[test]
+    fn test_shortened_tournament_name_derivation() {
+        assert_eq!(shorten("Alpha Bravo Delta Tournament"), "ABD");
+        assert_eq!(shorten("Alpha Bravo Delta"), "ABD");
+        assert_eq!(shorten("Alpha Bravo"), "ALB");
+        assert_eq!(shorten("Alpha"), "ALP");
     }
 }

--- a/tests/integration_tests/roles_tests.rs
+++ b/tests/integration_tests/roles_tests.rs
@@ -23,7 +23,7 @@ async fn admin_should_be_able_to_assign_roles() -> Result<(), OmniError> {
         .as_str()
         .unwrap()
         .to_owned();
-    let tournament_id = create_tournament(&app, "some tournament", &token)
+    let tournament_id = create_tournament(&app, "some tournament", None, &token)
         .await
         .json::<serde_json::Value>()
         .await
@@ -123,7 +123,7 @@ async fn granting_duplicate_roles_should_cause_conflicts() -> Result<(), OmniErr
         .as_str()
         .unwrap()
         .to_owned();
-    let tournament_id = create_tournament(&app, "some tournament", &token)
+    let tournament_id = create_tournament(&app, "some tournament", None, &token)
         .await
         .json::<serde_json::Value>()
         .await
@@ -175,7 +175,7 @@ async fn roles_should_be_visible_to_other_tournament_users() -> Result<(), OmniE
         .as_str()
         .unwrap()
         .to_owned();
-    let tournament_id = create_tournament(&app, "some tournament", &token)
+    let tournament_id = create_tournament(&app, "some tournament", None, &token)
         .await
         .json::<serde_json::Value>()
         .await
@@ -228,7 +228,7 @@ async fn roles_should_not_be_visible_to_other_users_from_outside_tournament(
         .unwrap()
         .to_owned();
     create_user(&app, mallory_handle, mallory_password, &token).await;
-    let tournament_id = create_tournament(&app, "some tournament", &token)
+    let tournament_id = create_tournament(&app, "some tournament", None, &token)
         .await
         .json::<serde_json::Value>()
         .await
@@ -271,7 +271,7 @@ async fn roles_should_be_modifiable() -> Result<(), OmniError> {
         .as_str()
         .unwrap()
         .to_owned();
-    let tournament_id = create_tournament(&app, "some tournament", &token)
+    let tournament_id = create_tournament(&app, "some tournament", None, &token)
         .await
         .json::<serde_json::Value>()
         .await
@@ -316,7 +316,7 @@ async fn roles_should_be_deletable() -> Result<(), OmniError> {
         .as_str()
         .unwrap()
         .to_owned();
-    let tournament_id = create_tournament(&app, "some tournament", &token)
+    let tournament_id = create_tournament(&app, "some tournament", None, &token)
         .await
         .json::<serde_json::Value>()
         .await

--- a/tests/integration_tests/roles_tests.rs
+++ b/tests/integration_tests/roles_tests.rs
@@ -23,7 +23,7 @@ async fn admin_should_be_able_to_assign_roles() -> Result<(), OmniError> {
         .as_str()
         .unwrap()
         .to_owned();
-    let tournament_id = create_tournament(&app, "some tournament", "st", &token)
+    let tournament_id = create_tournament(&app, "some tournament", &token)
         .await
         .json::<serde_json::Value>()
         .await
@@ -123,7 +123,7 @@ async fn granting_duplicate_roles_should_cause_conflicts() -> Result<(), OmniErr
         .as_str()
         .unwrap()
         .to_owned();
-    let tournament_id = create_tournament(&app, "some tournament", "st", &token)
+    let tournament_id = create_tournament(&app, "some tournament", &token)
         .await
         .json::<serde_json::Value>()
         .await
@@ -175,7 +175,7 @@ async fn roles_should_be_visible_to_other_tournament_users() -> Result<(), OmniE
         .as_str()
         .unwrap()
         .to_owned();
-    let tournament_id = create_tournament(&app, "some tournament", "st", &token)
+    let tournament_id = create_tournament(&app, "some tournament", &token)
         .await
         .json::<serde_json::Value>()
         .await
@@ -228,7 +228,7 @@ async fn roles_should_not_be_visible_to_other_users_from_outside_tournament(
         .unwrap()
         .to_owned();
     create_user(&app, mallory_handle, mallory_password, &token).await;
-    let tournament_id = create_tournament(&app, "some tournament", "st", &token)
+    let tournament_id = create_tournament(&app, "some tournament", &token)
         .await
         .json::<serde_json::Value>()
         .await
@@ -271,7 +271,7 @@ async fn roles_should_be_modifiable() -> Result<(), OmniError> {
         .as_str()
         .unwrap()
         .to_owned();
-    let tournament_id = create_tournament(&app, "some tournament", "st", &token)
+    let tournament_id = create_tournament(&app, "some tournament", &token)
         .await
         .json::<serde_json::Value>()
         .await
@@ -316,7 +316,7 @@ async fn roles_should_be_deletable() -> Result<(), OmniError> {
         .as_str()
         .unwrap()
         .to_owned();
-    let tournament_id = create_tournament(&app, "some tournament", "st", &token)
+    let tournament_id = create_tournament(&app, "some tournament", &token)
         .await
         .json::<serde_json::Value>()
         .await

--- a/tests/integration_tests/tournament_tests.rs
+++ b/tests/integration_tests/tournament_tests.rs
@@ -38,8 +38,7 @@ async fn tournament_creation_should_be_possible_for_infrastructure_admin() {
 
     // WHEN
     let token = get_session_token_for_infrastructure_admin(&app).await;
-    let res =
-        create_tournament(&app, "Wrocławska Liga Debat", None, &token).await;
+    let res = create_tournament(&app, "Wrocławska Liga Debat", None, &token).await;
 
     // THEN
     assert_eq!(res.status(), StatusCode::OK);

--- a/tests/integration_tests/tournament_tests.rs
+++ b/tests/integration_tests/tournament_tests.rs
@@ -35,6 +35,20 @@ async fn tournament_creation_should_require_login() {
 async fn tournament_creation_should_be_possible_for_infrastructure_admin() {
     // GIVEN
     let app = TestApp::spawn().await;
+
+    // WHEN
+    let token = get_session_token_for_infrastructure_admin(&app).await;
+    let res =
+        create_tournament(&app, "Wrocławska Liga Debat", None, &token).await;
+
+    // THEN
+    assert_eq!(res.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn tournament_creation_should_be_possible_with_user_defined_shortened_name() {
+    // GIVEN
+    let app = TestApp::spawn().await;
     let short_name_str = "WrLD";
     let shortened_name: Option<String> = Some(short_name_str.to_string());
 

--- a/tests/integration_tests/tournament_tests.rs
+++ b/tests/integration_tests/tournament_tests.rs
@@ -38,7 +38,7 @@ async fn tournament_creation_should_be_possible_for_infrastructure_admin() {
 
     // WHEN
     let token = get_session_token_for_infrastructure_admin(&app).await;
-    let res = create_tournament(&app, "Wrocławska Liga Debat", "WrLD", &token).await;
+    let res = create_tournament(&app, "Wrocławska Liga Debat", &token).await;
 
     // THEN
     assert_eq!(res.status(), StatusCode::OK);
@@ -54,10 +54,11 @@ async fn tournament_creation_should_impossible_for_other_users() {
     let response = create_tournament(
         &app,
         "illegal tournament",
-        "will not be created",
         &user_token,
     )
     .await;
+
+
 
     // THEN
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
@@ -69,13 +70,12 @@ async fn tournament_names_should_not_allow_duplicates() {
     let app = TestApp::spawn().await;
 
     let full_name = "WrocÅ‚awska Liga Debat";
-    let shortened_name = "WrLD";
     let token = get_session_token_for_infrastructure_admin(&app).await;
 
     // WHEN
-    let first_response = create_tournament(&app, full_name, shortened_name, &token).await;
+    let first_response = create_tournament(&app, full_name, &token).await;
     let second_response =
-        create_tournament(&app, full_name, shortened_name, &token).await;
+        create_tournament(&app, full_name, &token).await;
 
     // THEN
     assert_eq!(first_response.status(), StatusCode::OK);

--- a/tests/integration_tests/tournament_tests.rs
+++ b/tests/integration_tests/tournament_tests.rs
@@ -35,10 +35,13 @@ async fn tournament_creation_should_require_login() {
 async fn tournament_creation_should_be_possible_for_infrastructure_admin() {
     // GIVEN
     let app = TestApp::spawn().await;
+    let short_name_str = "WrLD";
+    let shortened_name: Option<String> = Some(short_name_str.to_string());
 
     // WHEN
     let token = get_session_token_for_infrastructure_admin(&app).await;
-    let res = create_tournament(&app, "Wrocławska Liga Debat", &token).await;
+    let res =
+        create_tournament(&app, "Wrocławska Liga Debat", shortened_name, &token).await;
 
     // THEN
     assert_eq!(res.status(), StatusCode::OK);
@@ -51,7 +54,7 @@ async fn tournament_creation_should_impossible_for_other_users() {
     let user_token = get_token_for_user_with_no_roles(&app).await;
 
     // WHEN
-    let response = create_tournament(&app, "illegal tournament", &user_token).await;
+    let response = create_tournament(&app, "illegal tournament", None, &user_token).await;
 
     // THEN
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
@@ -66,8 +69,8 @@ async fn tournament_names_should_not_allow_duplicates() {
     let token = get_session_token_for_infrastructure_admin(&app).await;
 
     // WHEN
-    let first_response = create_tournament(&app, full_name, &token).await;
-    let second_response = create_tournament(&app, full_name, &token).await;
+    let first_response = create_tournament(&app, full_name, None, &token).await;
+    let second_response = create_tournament(&app, full_name, None, &token).await;
 
     // THEN
     assert_eq!(first_response.status(), StatusCode::OK);

--- a/tests/integration_tests/tournament_tests.rs
+++ b/tests/integration_tests/tournament_tests.rs
@@ -51,14 +51,7 @@ async fn tournament_creation_should_impossible_for_other_users() {
     let user_token = get_token_for_user_with_no_roles(&app).await;
 
     // WHEN
-    let response = create_tournament(
-        &app,
-        "illegal tournament",
-        &user_token,
-    )
-    .await;
-
-
+    let response = create_tournament(&app, "illegal tournament", &user_token).await;
 
     // THEN
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
@@ -74,8 +67,7 @@ async fn tournament_names_should_not_allow_duplicates() {
 
     // WHEN
     let first_response = create_tournament(&app, full_name, &token).await;
-    let second_response =
-        create_tournament(&app, full_name, &token).await;
+    let second_response = create_tournament(&app, full_name, &token).await;
 
     // THEN
     assert_eq!(first_response.status(), StatusCode::OK);


### PR DESCRIPTION
**Automated tournament shortened name derivation**
Modified all tournaments-related files so shortened name is generated automatically on the tournament name basis.
Example of name shortening:
`"ThisIsMyTestTournament" -> "T20tl0mk"`

Logic behind name shortening:
1. Take the first letter: "T"
2. Take the length of name: "20"
3. Take the last letter: "t"
4. Add a unique 4-character sequence to prevent repetitions: "l0mk"

**Testing**
- [x] I have covered my code with tests.
- [x] I have run integration tests with `cargo test --tests` and ensured that they pass.
