### PR TITLE
Scrum 108 log tau version on startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3117,7 +3117,7 @@ dependencies = [
 
 [[package]]
 name = "tau"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "argon2",
  "aws-lc-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tau"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 repository = "https://github.com/debatecore/tau"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tau"
-version = "0.1.7"
+version = "0.1.8"
 description = "A project for versioning python-based tau development utils"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ pub mod tournaments;
 pub mod users;
 
 pub async fn start_server() {
-    setup::initialise_logging();
+    setup::initialise_logging().await;
     setup::read_environmental_variables();
     setup::check_secret_env_var();
 

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -23,7 +23,7 @@ mod teapot;
 mod tournament_routes;
 mod user_routes;
 mod verdicts_routes;
-mod version;
+pub mod version;
 
 pub fn routes() -> Router<AppState> {
     Router::new()

--- a/src/routes/swagger.rs
+++ b/src/routes/swagger.rs
@@ -22,6 +22,7 @@ use crate::routes::team_routes;
 use crate::routes::tournament_routes;
 use crate::routes::verdicts_routes;
 
+use crate::routes::version;
 use crate::tournaments;
 use crate::tournaments::affiliations;
 use crate::tournaments::attendees;
@@ -40,7 +41,6 @@ use crate::users::photourl;
 
 use super::health_check;
 use super::teapot;
-use super::version;
 
 pub fn route() -> Router<AppState> {
     Router::new()
@@ -53,7 +53,7 @@ pub fn route() -> Router<AppState> {
         health_check::live,
         health_check::health,
         teapot::route,
-        version::version,
+        version::get_semver_version,
         version::version_details,
         tournament_routes::create_tournament,
         tournament_routes::get_tournament_by_id,

--- a/src/routes/version.rs
+++ b/src/routes/version.rs
@@ -7,7 +7,7 @@ use crate::setup::AppState;
 
 pub fn route() -> Router<AppState> {
     Router::new()
-        .route("/version", get(version))
+        .route("/version", get(get_semver_version))
         .route("/version-details", get(version_details))
 }
 
@@ -45,7 +45,7 @@ pub struct GitInfo {
         body = str,
     ))
 )]
-async fn version() -> &'static str {
+pub async fn get_semver_version() -> &'static str {
     env!("CARGO_PKG_VERSION")
 }
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1,3 +1,4 @@
+use crate::routes::version::get_semver_version;
 use axum::http::{header::CONTENT_TYPE, HeaderValue, Method};
 use sqlx::{Pool, Postgres};
 use std::net::{Ipv4Addr, SocketAddrV4};
@@ -14,13 +15,14 @@ const CRYPTO_SECRET_ERROR: &str = "Could not read SECRET. Is it valid UTF-8?";
 #[allow(dead_code)]
 const FRONTEND_ORIGIN_NOT_SET: &str = "FRONTEND_ORIGIN is not set. Please provide a valid URL leading to an accepted origin.";
 
-pub fn initialise_logging() {
+pub async fn initialise_logging() {
     let subscriber = FmtSubscriber::builder()
         .with_max_level(Level::INFO)
         .finish();
     tracing::subscriber::set_global_default(subscriber)
         .expect("setting default tracing subscriber failed!");
     info!("Response cannon spinning up...");
+    info!("Current version: {}", get_semver_version().await);
 }
 
 pub fn report_listener_socket_addr(listener: &TcpListener) {

--- a/uv.lock
+++ b/uv.lock
@@ -125,7 +125,7 @@ wheels = [
 
 [[package]]
 name = "tau"
-version = "0.1.0"
+version = "0.1.8"
 source = { virtual = "." }
 dependencies = [
     { name = "eralchemy" },


### PR DESCRIPTION
**Introduced changes**
This PR introduces logging tau version on startup, for example:
```
2026-05-22T07:08:13.270356Z  INFO tau::setup: Response cannon spinning up...
2026-05-22T07:08:13.270393Z  INFO tau::setup: Current version: 0.1.8
```

**Testing**
- [ ] ~~I have covered my code with tests~~ (not applicable)
- [x] I have run integration tests with `cargo test --tests` and ensured that they pass.
