### PR TITLE
SCRUM-114 Log a link to swagger documentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3117,7 +3117,7 @@ dependencies = [
 
 [[package]]
 name = "tau"
-version = "0.1.11"
+version = "0.1.14"
 dependencies = [
  "argon2",
  "aws-lc-rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3117,7 +3117,7 @@ dependencies = [
 
 [[package]]
 name = "tau"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "argon2",
  "aws-lc-rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3117,7 +3117,7 @@ dependencies = [
 
 [[package]]
 name = "tau"
-version = "0.1.12"
+version = "0.1.15"
 dependencies = [
  "argon2",
  "aws-lc-rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3117,7 +3117,7 @@ dependencies = [
 
 [[package]]
 name = "tau"
-version = "0.1.14"
+version = "0.1.12"
 dependencies = [
  "argon2",
  "aws-lc-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tau"
-version = "0.1.12"
+version = "0.1.15"
 edition = "2021"
 repository = "https://github.com/debatecore/tau"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tau"
-version = "0.1.14"
+version = "0.1.12"
 edition = "2021"
 repository = "https://github.com/debatecore/tau"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tau"
-version = "0.1.11"
+version = "0.1.14"
 edition = "2021"
 repository = "https://github.com/debatecore/tau"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tau"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 repository = "https://github.com/debatecore/tau"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tau"
-version = "0.1.14"
+version = "0.1.12"
 description = "A project for versioning python-based tau development utils"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tau"
-version = "0.1.12"
+version = "0.1.15"
 description = "A project for versioning python-based tau development utils"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tau"
-version = "0.1.10"
+version = "0.1.11"
 description = "A project for versioning python-based tau development utils"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tau"
-version = "0.1.11"
+version = "0.1.14"
 description = "A project for versioning python-based tau development utils"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -34,6 +34,7 @@ pub fn report_listener_socket_addr(listener: &TcpListener) {
         }
     };
     info!("Listener socket address is: {}", addr.to_string());
+    info!("API documentation can be accessed at: http://localhost:{}/swagger-ui/#/", addr.port());
 }
 
 fn get_env_port() -> u16 {

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -34,7 +34,10 @@ pub fn report_listener_socket_addr(listener: &TcpListener) {
         }
     };
     info!("Listener socket address is: {}", addr.to_string());
-    info!("API documentation can be accessed at: http://localhost:{}/swagger-ui/#/", addr.port());
+    info!(
+        "API documentation can be accessed at: http://localhost:{}/swagger-ui/#/",
+        addr.port()
+    );
 }
 
 fn get_env_port() -> u16 {


### PR DESCRIPTION
**Introduced changes**
New info message command is added under of the report_listener_socket_adress function defined in the setup.rs file. 
The new info log message displays the Swagger UI URL with the actual port, which is 2023 for the current case.


**Testing**
cargo run command applied inside of the terminal and displayed log message is observed. Screenshot attached to the pull request.

<img width="1047" height="302" alt="Screenshot 2026-05-31 212621" src="https://github.com/user-attachments/assets/cec4f724-e816-47d8-a8d5-c169900c4ec8" />
