### PR TITLE
Scrum 84 container registry tau

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -3,6 +3,8 @@ name: Publish a Docker Image
 on:
   push:
     branches: ["master"]
+  pull_request:
+    branches: ["master"]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -15,6 +15,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -39,6 +39,6 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ steps.reponame-lower.outputs.name }}:latest
-            ghcr.io/${{ steps.reponame-lower.outputs.name }}:test
+            ghcr.io/${{ steps.reponame-lower.outputs.name }}:v${{ vars.CRATE_VERSION }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           enable-cache: true
 
-      - name: Get version number
+      - name: Get crate version
         run: CRATE_VERSION=$(python get_version_number.py); echo "CRATE_VERSION=$CRATE_VERSION" >> $GITHUB_ENV
 
       - name: Log in to GitHub Container Registry

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -3,8 +3,9 @@ name: Publish a Docker Image
 on:
   push:
     branches: ["master"]
-  pull_request:
-    branches: ["master"]
+    paths:
+      - "src/**"
+      - "Cargo.lock"
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -51,7 +51,7 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}:latest
             ghcr.io/${{ github.repository }}:v${{ env.CRATE_VERSION }}
-            cache-from: type=gha
-            cache-to: type=gha,mode=max
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -10,8 +10,10 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  publish-docker-image:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -45,7 +45,7 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: |
-            ghcr.io/${{ steps.reponame-lower.outputs.name }}:latest
-            ghcr.io/${{ steps.reponame-lower.outputs.name }}:v${{ vars.CRATE_VERSION }}
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:v${{ vars.CRATE_VERSION }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -49,3 +49,5 @@ jobs:
             ghcr.io/${{ github.repository }}:v${{ vars.CRATE_VERSION }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -39,6 +39,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          enable-cache: true
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
@@ -48,8 +50,8 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ github.repository }}:latest
-            ghcr.io/${{ github.repository }}:v${{ vars.CRATE_VERSION }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+            ghcr.io/${{ github.repository }}:v${{ env.CRATE_VERSION }}
+            cache-from: type=gha
+            cache-to: type=gha,mode=max
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -1,0 +1,44 @@
+name: Publish a Docker Image
+
+on:
+  push:
+    branches: ["master"]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Get version number
+        run: CRATE_VERSION=$(python get_version_number.py); echo "CRATE_VERSION=$CRATE_VERSION" >> $GITHUB_ENV
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ steps.reponame-lower.outputs.name }}:latest
+            ghcr.io/${{ steps.reponame-lower.outputs.name }}:test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -26,7 +26,7 @@ jobs:
           enable-cache: true
 
       - name: Get crate version
-        run: CRATE_VERSION=$(python get_version_number.py); echo "CRATE_VERSION=$CRATE_VERSION" >> $GITHUB_ENV
+        run: CRATE_VERSION=$(python scripts/get_version_number.py); echo "CRATE_VERSION=$CRATE_VERSION" >> $GITHUB_ENV
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3117,7 +3117,7 @@ dependencies = [
 
 [[package]]
 name = "tau"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "argon2",
  "aws-lc-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tau"
-version = "0.1.16"
+version = "0.1.17"
 edition = "2021"
 repository = "https://github.com/debatecore/tau"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tau"
-version = "0.1.16"
+version = "0.1.17"
 description = "A project for versioning python-based tau development utils"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/get_version_number.py
+++ b/scripts/get_version_number.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+from check_version import extract_version
+
+VERSION_FILE = "Cargo.toml"
+
+
+def main():
+    print(extract_version(VERSION_FILE, Path(VERSION_FILE).read_text()))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -125,7 +125,7 @@ wheels = [
 
 [[package]]
 name = "tau"
-version = "0.1.8"
+version = "0.1.10"
 source = { virtual = "." }
 dependencies = [
     { name = "eralchemy" },


### PR DESCRIPTION
**Introduced changes**
This pull request introduces publishing `tau` docker images via GitHub Container Registry on pushing to the master branch.

**Testing**
~~- [ ] I have covered my code with tests.~~
~~- [ ] I have run integration tests with `cargo test --tests` and ensured that they pass.~~
- [x] Using this pull request, I published the image and pulled it onto my local machine. One last check will be required after merging this PR (i.e. to see whether the new version gets published after the merge).
```
# docker run ghcr.io/debatecore/tau:latest 
Unable to find image 'ghcr.io/debatecore/tau:latest' locally
latest: Pulling from debatecore/tau
Digest: sha256:124deba5176b3cb61861199c681ec4cbf1ddd39cbaeb3e1b80ade0f99f2d6d88
Status: Downloaded newer image for ghcr.io/debatecore/tau:latest
2026-06-02T12:50:34.896493Z  INFO tau::setup: Response cannon spinning up...
2026-06-02T12:50:34.896522Z  INFO tau::setup: Current version: 0.1.16

```