### PR TITLE
refactor: html coverage report deployment + package versioning

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -62,12 +62,41 @@ jobs:
           set -o pipefail
           echo "### Coverage report" >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
-          cargo llvm-cov --workspace --tests --verbose 2>&1 | tee >(sed 's/^/    /' >> "$GITHUB_STEP_SUMMARY")
+          cargo llvm-cov --workspace --tests --verbose --html --output-dir target/llvm-cov/html 2>&1 | tee >(sed 's/^/    /' >> "$GITHUB_STEP_SUMMARY")
           echo '```' >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload coverage HTML artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: target/llvm-cov/html
       - name: Build Docker image
         run: docker build -t tau:test .
       - name: Build Docker Compose
         run: docker compose build server-prod
+
+  deploy-pages:
+    name: Deploy coverage to GitHub Pages
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    steps:
+      - name: Download coverage report artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-report
+          path: target/llvm-cov/html
+
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: target/llvm-cov/html
+
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v1
+
+      - name: Show GitHub Pages URL
+        run: |
+          echo "GitHub Pages site should be available at: https://${GITHUB_REPOSITORY_OWNER}.github.io/${GITHUB_REPOSITORY#*/}/"
 
   version-check:
     name: Check package version

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3117,7 +3117,7 @@ dependencies = [
 
 [[package]]
 name = "tau"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "argon2",
  "aws-lc-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tau"
-version = "0.1.17"
+version = "0.1.18"
 edition = "2021"
 repository = "https://github.com/debatecore/tau"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tau"
-version = "0.1.17"
+version = "0.1.18"
 description = "A project for versioning python-based tau development utils"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
**Introduced changes**
Updated [rust.yml] to:

generate HTML coverage with cargo llvm-cov --html --output-dir target/llvm-cov/html
upload the HTML report as an artifact named coverage-report
deploy the generated report to GitHub Pages via actions/upload-pages-artifact@v1 and actions/deploy-pages@v1

**Testing**
deploy-pages runs only on push to master
PR builds still generate and upload the coverage artifact, but Pages deployment happens after merge/push to master
<img width="1887" height="881" alt="image" src="https://github.com/user-attachments/assets/b6ebbc88-e80d-42d7-b2f8-f62bbf01308c" />


